### PR TITLE
Use HTTPS instead of SSH for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "third_party/abseil-cpp"]
 	path = third_party/abseil-cpp
-	url = git@github.com:abseil/abseil-cpp.git
+	url = https://github.com/abseil/abseil-cpp.git
 	branch = lts_2020_02_25
 [submodule "third_party/googletest"]
 	path = third_party/googletest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git
 	branch = v1.10.x
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
-	url = git@github.com:protocolbuffers/protobuf.git
+	url = https://github.com/protocolbuffers/protobuf.git
 	branch = 3.12.x
 [submodule "third_party/rules_proto"]
 	path = third_party/rules_proto
-	url = git@github.com:bazelbuild/rules_proto.git
+	url = https://github.com/bazelbuild/rules_proto.git
 [submodule "third_party/glog"]
 	path = third_party/glog
-	url = git@github.com:google/glog.git
+	url = https://github.com/google/glog.git
 [submodule "third_party/re2"]
 	path = third_party/re2
-	url = git@github.com:google/re2.git
+	url = https://github.com/google/re2.git
 [submodule "third_party/p4runtime"]
 	path = third_party/p4runtime
-	url = git@github.com:p4lang/p4runtime.git
+	url = https://github.com/p4lang/p4runtime.git
 [submodule "third_party/googleapis"]
 	path = third_party/googleapis
-	url = git@github.com:googleapis/googleapis.git
+	url = https://github.com/googleapis/googleapis.git
 [submodule "third_party/p4c"]
 	path = third_party/p4c
-	url = git@github.com:p4lang/p4c.git
+	url = https://github.com/p4lang/p4c.git


### PR DESCRIPTION
This avoids errors on machines without ssh key.
