### PR TITLE
Avoid relying on undefined output in golden test.

### DIFF
--- a/p4_constraints/backend/interpreter_test.cc
+++ b/p4_constraints/backend/interpreter_test.cc
@@ -47,7 +47,7 @@ class EntryMeetsConstraintTest : public ::testing::Test {
  public:
   const Type kUnknown = ParseTextProtoOrDie<Type>("unknown {}");
   const Type kUnsupported =
-      ParseTextProtoOrDie<Type>(R"(unsupported { name: "optional" })");
+      ParseTextProtoOrDie<Type>(R"pb(unsupported { name: "optional" })pb");
   const Type kBool = ParseTextProtoOrDie<Type>("boolean {}");
   const Type kArbitraryInt = ParseTextProtoOrDie<Type>("arbitrary_int {}");
   const Type kFixedUnsigned16 =
@@ -93,13 +93,13 @@ class EntryMeetsConstraintTest : public ::testing::Test {
       }};
 
   const p4::v1::TableEntry kTableEntry =
-      ParseTextProtoOrDie<p4::v1::TableEntry>(R"PROTO(
+      ParseTextProtoOrDie<p4::v1::TableEntry>(R"pb(
         table_id: 1
         match {
           field_id: 1
           exact { value: "1234" }
         }
-      )PROTO");
+      )pb");
 
   ConstraintInfo MakeConstraintInfo(const Expression& expr) {
     TableInfo table_info = kTableInfo;

--- a/p4_constraints/cli/BUILD.bazel
+++ b/p4_constraints/cli/BUILD.bazel
@@ -17,6 +17,7 @@ cc_binary(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
         "@com_google_protobuf//:protobuf",

--- a/p4_constraints/cli/p4check.cc
+++ b/p4_constraints/cli/p4check.cc
@@ -32,6 +32,7 @@
 #include "absl/flags/usage.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
 #include "absl/types/variant.h"
@@ -56,6 +57,11 @@ constexpr char kUsage[] =
 // See P4Runtime specification, "6.3 ID Allocation for P4Info Objects".
 uint32_t CoerceToTableId(uint32_t table_id) {
   return (table_id & 0x00FFFFFF) | (p4::config::v1::P4Ids::TABLE << 24);
+}
+
+std::string ToString(const absl::Status& status) {
+  return absl::StrCat(absl::StatusCodeToString(status.code()), ": ",
+                      status.message());
 }
 
 int main(int argc, char** argv) {
@@ -130,7 +136,7 @@ int main(int argc, char** argv) {
     // Check entry.
     absl::StatusOr<bool> result = EntryMeetsConstraint(entry, *constraint_info);
     if (!result.ok()) {
-      std::cout << "Error: " << result.status() << "\n\n";
+      std::cout << "Error: " << ToString(result.status()) << "\n\n";
       continue;
     }
     std::cout << "constraint " << (result.value() ? "satisfied" : "violated")

--- a/p4_constraints/frontend/parser_test.cc
+++ b/p4_constraints/frontend/parser_test.cc
@@ -78,170 +78,173 @@ struct ParserTest : public ::testing::Test {
 };
 
 TEST_F(ParserTest, Positive) {
-  const std::pair<std::vector<Token>, std::string> tests[] = {
-      // Boolean constants.
-      {{kTrue}, "boolean_constant: true"},
-      {{kFalse}, "boolean_constant: false"},
+  const std::pair<std::vector<Token>, std::string> tests[] =
+      {
+          // Boolean constants.
+          {{kTrue}, "boolean_constant: true"},
+          {{kFalse}, "boolean_constant: false"},
 
-      // Tests, comparison operators, numerals.
-      {{kId, kEq, Binary("11")}, R"PROTO(binary_expression: {
-                                           left: { key: "" },
-                                           binop: EQ,
-                                           right: { integer_constant: "3" }
-                                         })PROTO"},
-      {{kId, kNe, Octary("11")}, R"PROTO(binary_expression: {
-                                           left: { key: "" },
-                                           binop: NE,
-                                           right: { integer_constant: "9" }
-                                         })PROTO"},
-      {{kId, kGt, Decimal("11")}, R"PROTO(binary_expression: {
+          // Tests, comparison operators, numerals.
+          {{kId, kEq, Binary("11")}, R"pb(binary_expression: {
                                             left: { key: "" },
-                                            binop: GT,
-                                            right: { integer_constant: "11" }
-                                          })PROTO"},
-      {{kId, kGe, Hexadec("11")}, R"PROTO(binary_expression: {
+                                            binop: EQ,
+                                            right: { integer_constant: "3" }
+                                          })pb"},
+          {{kId, kNe, Octary("11")}, R"pb(binary_expression: {
                                             left: { key: "" },
-                                            binop: GE,
-                                            right: { integer_constant: "17" }
-                                          })PROTO"},
-      {{kId, kLt, Hexadec("1f")}, R"PROTO(binary_expression: {
-                                            left: { key: "" },
-                                            binop: LT,
-                                            right: { integer_constant: "31" }
-                                          })PROTO"},
-      {{kId, kLe, Hexadec("af")},
-       R"PROTO(binary_expression: {
-                 left: { key: "" },
-                 binop: LE,
-                 right: { integer_constant: "175" }
-               })PROTO"},
+                                            binop: NE,
+                                            right: { integer_constant: "9" }
+                                          })pb"},
+          {{kId, kGt, Decimal("11")}, R"pb(binary_expression: {
+                                             left: { key: "" },
+                                             binop: GT,
+                                             right: { integer_constant: "11" }
+                                           })pb"},
+          {{kId, kGe, Hexadec("11")}, R"pb(binary_expression: {
+                                             left: { key: "" },
+                                             binop: GE,
+                                             right: { integer_constant: "17" }
+                                           })pb"},
+          {{kId, kLt, Hexadec("1f")}, R"pb(binary_expression: {
+                                             left: { key: "" },
+                                             binop: LT,
+                                             right: { integer_constant: "31" }
+                                           })pb"},
+          {{kId, kLe, Hexadec("af")},
+           R"pb(binary_expression: {
+                  left: { key: "" },
+                  binop: LE,
+                  right: { integer_constant: "175" }
+                })pb"},
 
-      // Boolean negation.
-      {{kNot, kTrue}, R"(boolean_negation: {boolean_constant: true})"},
-      {{kNot, kFalse}, R"(boolean_negation: {boolean_constant: false})"},
-      {{kNot, kLpar, kId, kEq, Decimal("000123"), kRpar},
-       R"PROTO(boolean_negation: {
-                 binary_expression: {
-                   left: { key: "" },
-                   binop: EQ,
-                   right: { integer_constant: "123" }
-                 }
-               })PROTO"},
-      {{kNot, kNot, kTrue},
-       R"PROTO(boolean_negation: {
-                 boolean_negation: { boolean_constant: true }
-               })PROTO"},
+          // Boolean negation.
+          {{kNot, kTrue}, R"(boolean_negation: {boolean_constant: true})"},
+          {{kNot, kFalse}, R"(boolean_negation: {boolean_constant: false})"},
+          {{kNot, kLpar, kId, kEq, Decimal("000123"), kRpar},
+           R"pb(boolean_negation: {
+                  binary_expression: {
+                    left: { key: "" },
+                    binop: EQ,
+                    right: { integer_constant: "123" }
+                  }
+                })pb"},
+          {{kNot, kNot, kTrue},
+           R"pb(boolean_negation: {
+                  boolean_negation: { boolean_constant: true }
+                })pb"},
 
-      // Binary Boolean operators.
-      {{kTrue, kAnd, kTrue}, R"PROTO(binary_expression: {
+          // Binary Boolean operators.
+          {{kTrue, kAnd, kTrue}, R"pb(binary_expression: {
+                                        left: { boolean_constant: true },
+                                        binop: AND,
+                                        right: { boolean_constant: true }
+                                      })pb"},
+          {{kTrue, kOr, kTrue}, R"pb(binary_expression: {
                                        left: { boolean_constant: true },
-                                       binop: AND,
+                                       binop: OR,
                                        right: { boolean_constant: true }
-                                     })PROTO"},
-      {{kTrue, kOr, kTrue}, R"PROTO(binary_expression: {
-                                      left: { boolean_constant: true },
-                                      binop: OR,
-                                      right: { boolean_constant: true }
-                                    })PROTO"},
-      {{kTrue, kImplies, kTrue}, R"PROTO(binary_expression: {
-                                           left: { boolean_constant: true },
-                                           binop: IMPLIES,
-                                           right: { boolean_constant: true }
-                                         })PROTO"},
+                                     })pb"},
+          {{kTrue, kImplies, kTrue}, R"pb(binary_expression: {
+                                            left: { boolean_constant: true },
+                                            binop: IMPLIES,
+                                            right: { boolean_constant: true }
+                                          })pb"},
 
-      // Associativity.
-      {{kTrue, kAnd, kTrue, kAnd, kTrue},
-       R"PROTO(binary_expression: {
-                 left: {
-                   binary_expression: {
-                     left: { boolean_constant: true },
-                     binop: AND,
-                     right: { boolean_constant: true }
-                   }
-                 },
-                 binop: AND,
-                 right: { boolean_constant: true }
-               })PROTO"},
-      {{kTrue, kAnd, kLpar, kTrue, kAnd, kTrue, kRpar},
-       R"PROTO(binary_expression: {
-                 left: { boolean_constant: true },
-                 binop: AND,
-                 right: {
-                   binary_expression: {
-                     left: { boolean_constant: true },
-                     binop: AND,
-                     right: { boolean_constant: true }
-                   }
-                 }
-               })PROTO"},
-      {{kTrue, kOr, kTrue, kOr, kTrue},
-       R"PROTO(binary_expression: {
-                 left: {
-                   binary_expression: {
-                     left: { boolean_constant: true },
-                     binop: OR,
-                     right: { boolean_constant: true }
-                   }
-                 },
-                 binop: OR,
-                 right: { boolean_constant: true }
-               })PROTO"},
-      {{kTrue, kOr, kLpar, kTrue, kOr, kTrue, kRpar},
-       R"PROTO(binary_expression: {
-                 left: { boolean_constant: true },
-                 binop: OR,
-                 right: {
-                   binary_expression: {
-                     left: { boolean_constant: true },
-                     binop: OR,
-                     right: { boolean_constant: true }
-                   }
-                 }
-               })PROTO"},
+          // Associativity.
+          {{kTrue, kAnd, kTrue, kAnd, kTrue},
+           R"pb(binary_expression: {
+                  left: {
+                    binary_expression: {
+                      left: { boolean_constant: true },
+                      binop: AND,
+                      right: { boolean_constant: true }
+                    }
+                  },
+                  binop: AND,
+                  right: { boolean_constant: true }
+                })pb"},
+          {{kTrue, kAnd, kLpar, kTrue, kAnd, kTrue, kRpar},
+           R"pb(binary_expression: {
+                  left: { boolean_constant: true },
+                  binop: AND,
+                  right: {
+                    binary_expression: {
+                      left: { boolean_constant: true },
+                      binop: AND,
+                      right: { boolean_constant: true }
+                    }
+                  }
+                })pb"},
+          {{kTrue, kOr, kTrue, kOr, kTrue},
+           R"pb(binary_expression: {
+                  left: {
+                    binary_expression: {
+                      left: { boolean_constant: true },
+                      binop: OR,
+                      right: { boolean_constant: true }
+                    }
+                  },
+                  binop: OR,
+                  right: { boolean_constant: true }
+                })pb"},
+          {{kTrue, kOr, kLpar, kTrue, kOr, kTrue, kRpar},
+           R"pb(binary_expression: {
+                  left: { boolean_constant: true },
+                  binop: OR,
+                  right: {
+                    binary_expression: {
+                      left: { boolean_constant: true },
+                      binop: OR,
+                      right: { boolean_constant: true }
+                    }
+                  }
+                })pb"},
 
-      // Precedence.
-      {{kNot, kTrue, kAnd, kTrue, kOr, kTrue, kImplies, kTrue},
-       R"PROTO(binary_expression: {
-                 binop: IMPLIES,
-                 left: {
-                   binary_expression: {
-                     binop: OR,
-                     left: {
-                       binary_expression: {
-                         binop: AND,
-                         left: { boolean_negation: { boolean_constant: true } },
-                         right: { boolean_constant: true },
-                       }
-                     },
-                     right: { boolean_constant: true },
-                   }
-                 }
-               })PROTO"},
-      {{kNot, kTrue, kImplies, kTrue, kOr, kTrue, kAnd, kTrue},
-       R"PROTO(binary_expression: {
-                 binop: IMPLIES,
-                 left: { boolean_negation: { boolean_constant: true } },
-                 right: {
-                   binary_expression: {
-                     binop: OR,
-                     left: { boolean_constant: true },
-                     right: {
-                       binary_expression: {
-                         binop: AND,
-                         left: { boolean_constant: true },
-                         right: { boolean_constant: true },
-                       }
-                     }
-                   }
-                 }
-               })PROTO"},
+          // Precedence.
+          {{kNot, kTrue, kAnd, kTrue, kOr, kTrue, kImplies, kTrue},
+           R"pb(binary_expression: {
+                  binop: IMPLIES,
+                  left: {
+                    binary_expression: {
+                      binop: OR,
+                      left: {
+                        binary_expression: {
+                          binop: AND,
+                          left: {
+                            boolean_negation: { boolean_constant: true }
+                          },
+                          right: { boolean_constant: true },
+                        }
+                      },
+                      right: { boolean_constant: true },
+                    }
+                  }
+                })pb"},
+          {{kNot, kTrue, kImplies, kTrue, kOr, kTrue, kAnd, kTrue},
+           R"pb(binary_expression: {
+                  binop: IMPLIES,
+                  left: { boolean_negation: { boolean_constant: true } },
+                  right: {
+                    binary_expression: {
+                      binop: OR,
+                      left: { boolean_constant: true },
+                      right: {
+                        binary_expression: {
+                          binop: AND,
+                          left: { boolean_constant: true },
+                          right: { boolean_constant: true },
+                        }
+                      }
+                    }
+                  }
+                })pb"},
 
-      // Parenthesis.
-      {{kLpar, kTrue, kRpar}, "boolean_constant: true"},
-      {{kLpar, kLpar, kTrue, kRpar, kRpar}, "boolean_constant: true"},
-      {{kLpar, kLpar, kLpar, kTrue, kRpar, kRpar, kRpar},
-       "boolean_constant: true"},
-  };
+          // Parenthesis.
+          {{kLpar, kTrue, kRpar}, "boolean_constant: true"},
+          {{kLpar, kLpar, kTrue, kRpar, kRpar}, "boolean_constant: true"},
+          {{kLpar, kLpar, kLpar, kTrue, kRpar, kRpar, kRpar},
+           "boolean_constant: true"},
+      };
 
   for (const auto& test : tests) {
     const auto& tokens = test.first;


### PR DESCRIPTION
Avoid relying on undefined output in golden test. In particular, the output produced by `std::ostream& operator<<` is not guaranteed to be stable for `absl::Status`, causing our end to end tests to brake in some settings.

The PR also includes some formatting changes.

No semantic changes.
