### PR TITLE
Implemented ReasonEntryViolatesConstraint

### DIFF
--- a/gutils/BUILD.bazel
+++ b/gutils/BUILD.bazel
@@ -72,3 +72,20 @@ cc_library(
         "@com_googlesource_code_re2//:re2",
     ],
 )
+
+cc_library(
+    name = "ordered_map",
+    hdrs = [
+        "ordered_map.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/container:btree",
+    ],
+)
+
+cc_library(
+    name = "overload",
+    hdrs = ["overload.h"],
+    visibility = ["//visibility:public"],
+)

--- a/gutils/ordered_map.h
+++ b/gutils/ordered_map.h
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_P4LANG_P4_CONSTRAINTS_GUTILS_ORDERED_MAP_H_
+#define THIRD_PARTY_P4LANG_P4_CONSTRAINTS_GUTILS_ORDERED_MAP_H_
+
+#include "absl/container/btree_map.h"
+namespace gutils {
+// Ordered view of an unordered Map. Useful for iterating over the map
+// in deterministic fashion. Note that the original map and its contents must
+// remain live (i.e. allocated) or else this will cause dangling references.
+template <typename M>
+absl::btree_map<typename M::key_type, const typename M::mapped_type&> Ordered(
+    const M& map) {
+  return absl::btree_map<typename M::key_type, const typename M::mapped_type&>(
+      map.begin(), map.end());
+}
+}  // namespace gutils
+#endif  // THIRD_PARTY_P4LANG_P4_CONSTRAINTS_GUTILS_ORDERED_MAP_H_

--- a/gutils/overload.h
+++ b/gutils/overload.h
@@ -1,0 +1,31 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_P4LANG_P4_CONSTRAINTS_GUTILS_OVERLOAD_H_
+#define THIRD_PARTY_P4LANG_P4_CONSTRAINTS_GUTILS_OVERLOAD_H_
+
+namespace gutils {
+
+// Useful in conjunction with {std,absl}::visit.
+// See https://en.cppreference.com/w/cpp/utility/variant/visit.
+template <class... Ts>
+struct Overload : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+Overload(Ts...) -> Overload<Ts...>;
+
+}  // namespace gutils
+
+#endif  // THIRD_PARTY_P4LANG_P4_CONSTRAINTS_GUTILS_OVERLOAD_H_

--- a/p4_constraints/BUILD.bazel
+++ b/p4_constraints/BUILD.bazel
@@ -27,10 +27,9 @@ cc_test(
     srcs = ["ast_test.cc"],
     deps = [
         ":ast",
-        "//gutils:status",
+        ":ast_cc_proto",
+        "//gutils:parse_text_proto",
         "//gutils:status_matchers",
-        "//p4_constraints/frontend:lexer",
-        "//p4_constraints/frontend:parser",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/p4_constraints/backend/BUILD.bazel
+++ b/p4_constraints/backend/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//third_party/p4lang_p4_constraints/e2e_tests:p4check.bzl", "diff_test")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],  # Apache 2.0
@@ -13,6 +15,8 @@ cc_library(
     ],
     deps = [
         ":constraint_info",
+        "//gutils:ordered_map",
+        "//gutils:overload",
         "//gutils:ret_check",
         "//gutils:status",
         "//p4_constraints:ast",
@@ -25,6 +29,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:variant",
     ],
 )
 
@@ -41,13 +46,14 @@ cc_test(
         ":interpreter",
         "//gutils:parse_text_proto",
         "//gutils:status_matchers",
+        "//p4_constraints:ast",
         "//p4_constraints:ast_cc_proto",
         "//p4_constraints/frontend:lexer",
         "//p4_constraints/frontend:parser",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
@@ -64,7 +70,6 @@ cc_library(
         "type_checker.h",
     ],
     deps = [
-        "//gutils:ret_check",
         "//gutils:status",
         "//p4_constraints:ast",
         "//p4_constraints:ast_cc_proto",
@@ -81,6 +86,40 @@ cc_library(
         "@com_google_absl//absl/types:variant",
         "@com_googlesource_code_re2//:re2",
     ],
+)
+
+cc_binary(
+    name = "interpreter_golden_test_runner",
+    testonly = True,
+    srcs = ["interpreter_golden_test_runner.cc"],
+    deps = [
+        ":constraint_info",
+        ":interpreter",
+        "//gutils:ordered_map",
+        "//gutils:parse_text_proto",
+        "//gutils:status",
+        "//p4_constraints:ast_cc_proto",
+        "//p4_constraints/frontend:lexer",
+        "//p4_constraints/frontend:parser",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+genrule(
+    name = "interpreter_golden_test_runner_output",
+    testonly = True,
+    outs = ["interpreter_golden_test_runner.output"],
+    cmd = "$(location :interpreter_golden_test_runner) > $(OUTS)",
+    tools = [":interpreter_golden_test_runner"],
+)
+
+diff_test(
+    name = "interpreter_golden_test",
+    actual = ":interpreter_golden_test_runner_output",
+    expected = "interpreter_golden_test_runner.expected",
 )
 
 cc_test(

--- a/p4_constraints/backend/constraint_info.cc
+++ b/p4_constraints/backend/constraint_info.cc
@@ -26,7 +26,6 @@
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
-#include "gutils/ret_check.h"
 #include "gutils/status_macros.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "p4_constraints/ast.pb.h"

--- a/p4_constraints/backend/constraint_info.h
+++ b/p4_constraints/backend/constraint_info.h
@@ -28,7 +28,6 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/variant.h"
 #include "p4/config/v1/p4info.pb.h"

--- a/p4_constraints/backend/interpreter_golden_test_runner.cc
+++ b/p4_constraints/backend/interpreter_golden_test_runner.cc
@@ -1,0 +1,169 @@
+// Copyright 2020 The P4-Constraints Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generates file for golden testing of `ReasonEntryViolatesConstraint` in
+// interpreter.cc. Expected output is `interpreter_golden_test_runner.expected`
+
+#include "absl/log/check.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_join.h"
+#include "gutils/ordered_map.h"
+#include "gutils/parse_text_proto.h"
+#include "gutils/status_macros.h"
+#include "p4_constraints/ast.proto.h"
+#include "p4_constraints/backend/interpreter.h"
+#include "p4_constraints/backend/type_checker.h"
+#include "p4_constraints/frontend/lexer.h"
+#include "p4_constraints/frontend/parser.h"
+#include "third_party/p4lang_p4runtime/proto/p4/v1/p4runtime.proto.h"
+
+namespace p4_constraints {
+namespace internal_interpreter {
+
+using ::gutils::ParseTextProtoOrDie;
+using ::p4_constraints::ast::Expression;
+using ::p4_constraints::ast::SourceLocation;
+using ::p4_constraints::ast::Type;
+
+// A test case for `ReasonEntryViolatesConstraint` function
+struct TestCase {
+  std::string constraint;
+  p4::v1::TableEntry table_entry;
+};
+
+ConstraintInfo MakeConstraintInfo(Expression& expr) {
+  const Type kExact32 = ParseTextProtoOrDie<Type>("exact { bitwidth: 32 }");
+  const Type kTernary32 = ParseTextProtoOrDie<Type>("ternary { bitwidth: 32 }");
+  const Type kLpm32 = ParseTextProtoOrDie<Type>("lpm { bitwidth: 32 }");
+  const Type kRange32 = ParseTextProtoOrDie<Type>("range { bitwidth: 32 }");
+  const Type kOptional32 =
+      ParseTextProtoOrDie<Type>("optional_match { bitwidth: 32 }");
+  const TableInfo kTableInfo{
+      .id = 1,
+      .name = "table",
+      .constraint = {},  // To be filled in later.
+      .keys_by_id =
+          {
+              {1, {1, "exact32", kExact32}},
+              // For testing purposes, fine to omit the other keys here.
+          },
+      .keys_by_name = {
+          {"exact32", {1, "exact32", kExact32}},
+          {"ternary32", {2, "ternary32", kTernary32}},
+          {"lpm32", {3, "lpm32", kLpm32}},
+          {"range32", {4, "range32", kRange32}},
+          {"optional32", {5, "optional32", kOptional32}},
+      }};
+
+  TableInfo table_info = kTableInfo;
+  CHECK_OK(InferAndCheckTypes(&(expr), kTableInfo));
+  table_info.constraint = expr;
+  return {{table_info.id, table_info}};
+}
+
+// NOTE: Test cases only define "exact" for brevity but kTableInfo is
+// composed of several keys. These undeclared keys are implicitly set to hold
+// "catchall" values (i.e. range=[min,max], ternary=*)
+std::vector<TestCase> TestCases() {
+  std::vector<TestCase> test_cases;
+  test_cases.push_back(TestCase{
+      .constraint = "true;",
+      .table_entry = ParseTextProtoOrDie<p4::v1::TableEntry>(R"pb(
+        table_id: 1
+        match {
+          field_id: 1
+          exact { value: "\012" }
+        }
+      )pb"),
+  });
+
+  test_cases.push_back(TestCase{
+      .constraint = "exact32::value != 10 || exact32::value == 10;",
+      .table_entry = ParseTextProtoOrDie<p4::v1::TableEntry>(R"pb(
+        table_id: 1
+        match {
+          field_id: 1
+          exact { value: "\012" }
+        }
+      )pb"),
+  });
+
+  test_cases.push_back(TestCase{
+      .constraint = "exact32::value > 6 && exact32::value < 5;",
+      .table_entry = ParseTextProtoOrDie<p4::v1::TableEntry>(R"pb(
+        table_id: 1
+        match {
+          field_id: 1
+          exact { value: "\012" }
+        }
+      )pb"),
+  });
+
+  test_cases.push_back(TestCase{
+      .constraint = "exact32::value > 5 && !(exact32::value == 10);",
+      .table_entry = ParseTextProtoOrDie<p4::v1::TableEntry>(R"pb(
+        table_id: 1
+        match {
+          field_id: 1
+          exact { value: "\012" }
+        }
+      )pb"),
+  });
+
+  return test_cases;
+}
+
+std::string EntryToString(const TableEntry& entry) {
+  std::string key_info = absl::StrJoin(
+      gutils::Ordered(entry.keys), "\n", [](std::string* out, auto pair) {
+        absl::StrAppend(out, "Key:\"", pair.first,
+                        "\" -> Value: ", EvalResultToString(pair.second));
+      });
+  return absl::StrFormat(
+      "Table Name:\"%s\"\n"
+      "Priority:%d\n"
+      "Key Info\n"
+      "%s\n",
+      entry.table_name, entry.priority, key_info);
+}
+
+absl::Status main() {
+  for (const TestCase& test_case : TestCases()) {
+    ASSIGN_OR_RETURN(
+        Expression constraint,
+        ParseConstraint(Tokenize(test_case.constraint, SourceLocation())));
+    const ConstraintInfo table_info = MakeConstraintInfo(constraint);
+
+    ASSIGN_OR_RETURN(TableEntry input,
+                     ParseEntry(test_case.table_entry, table_info.at(1)));
+    std::cout << "=== INPUT ===\n"
+              << "--- Constraint ---\n"
+              << test_case.constraint << "\n--- Table Entry ---\n"
+              << EntryToString(input);
+
+    absl::StatusOr<std::string> result =
+        ReasonEntryViolatesConstraint(test_case.table_entry, table_info);
+    if (result.ok()) {
+      std::cout << "=== OUTPUT ===\n" << *result << "\n";
+    } else {
+      std::cout << "=== ERROR ===\n" << result.status();
+    }
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace internal_interpreter
+}  // namespace p4_constraints
+
+int main() { CHECK_OK(p4_constraints::internal_interpreter::main()); }

--- a/p4_constraints/backend/interpreter_golden_test_runner.expected
+++ b/p4_constraints/backend/interpreter_golden_test_runner.expected
@@ -1,0 +1,220 @@
+=== INPUT ===
+--- Constraint ---
+true;
+--- Table Entry ---
+Table Name:"table"
+Priority:0
+Key Info
+Key:"exact32" -> Value: Exact{.value = 10}
+Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
+Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
+Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
+Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+=== OUTPUT ===
+
+=== INPUT ===
+--- Constraint ---
+exact32::value != 10 || exact32::value == 10;
+--- Table Entry ---
+Table Name:"table"
+Priority:0
+Key Info
+Key:"exact32" -> Value: Exact{.value = 10}
+Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
+Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
+Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
+Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+=== OUTPUT ===
+
+=== INPUT ===
+--- Constraint ---
+exact32::value > 6 && exact32::value < 5;
+--- Table Entry ---
+Table Name:"table"
+Priority:0
+Key Info
+Key:"exact32" -> Value: Exact{.value = 10}
+Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
+Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
+Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
+Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+=== OUTPUT ===
+All entries must satisfy:
+
+start_location 	 {
+  column: 22
+}
+end_location {
+  column: 40
+}
+type {
+  boolean {
+  }
+}
+binary_expression {
+  binop: LT
+  left {
+    start_location {
+      column: 22
+    }
+    end_location {
+      column: 36
+    }
+    type {
+      fixed_unsigned {
+        bitwidth: 32
+      }
+    }
+    field_access {
+      field: "value"
+      expr {
+        start_location {
+          column: 22
+        }
+        end_location {
+          column: 29
+        }
+        type {
+          exact {
+            bitwidth: 32
+          }
+        }
+        key: "exact32"
+      }
+    }
+  }
+  right {
+    start_location {
+      column: 39
+    }
+    end_location {
+      column: 40
+    }
+    type {
+      fixed_unsigned {
+        bitwidth: 32
+      }
+    }
+    type_cast {
+      start_location {
+        column: 39
+      }
+      end_location {
+        column: 40
+      }
+      type {
+        arbitrary_int {
+        }
+      }
+      integer_constant: "5"
+    }
+  }
+}
+
+But your entry did not
+>>>Entry Info<<<
+Table Name:"table"
+Priority:0
+Key Info
+Key:"exact32" -> Value: Exact{.value = 10}
+Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
+Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
+Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
+Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+
+=== INPUT ===
+--- Constraint ---
+exact32::value > 5 && !(exact32::value == 10);
+--- Table Entry ---
+Table Name:"table"
+Priority:0
+Key Info
+Key:"exact32" -> Value: Exact{.value = 10}
+Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
+Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
+Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
+Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+=== OUTPUT ===
+All entries must not satisfy:
+
+start_location 	 {
+  column: 24
+}
+end_location {
+  column: 44
+}
+type {
+  boolean {
+  }
+}
+binary_expression {
+  binop: EQ
+  left {
+    start_location {
+      column: 24
+    }
+    end_location {
+      column: 38
+    }
+    type {
+      fixed_unsigned {
+        bitwidth: 32
+      }
+    }
+    field_access {
+      field: "value"
+      expr {
+        start_location {
+          column: 24
+        }
+        end_location {
+          column: 31
+        }
+        type {
+          exact {
+            bitwidth: 32
+          }
+        }
+        key: "exact32"
+      }
+    }
+  }
+  right {
+    start_location {
+      column: 42
+    }
+    end_location {
+      column: 44
+    }
+    type {
+      fixed_unsigned {
+        bitwidth: 32
+      }
+    }
+    type_cast {
+      start_location {
+        column: 42
+      }
+      end_location {
+        column: 44
+      }
+      type {
+        arbitrary_int {
+        }
+      }
+      integer_constant: "10"
+    }
+  }
+}
+
+But your entry did
+>>>Entry Info<<<
+Table Name:"table"
+Priority:0
+Key Info
+Key:"exact32" -> Value: Exact{.value = 10}
+Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
+Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
+Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
+Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+


### PR DESCRIPTION
Implemented ReasonEntryViolatesConstraint
-MinimalSubexpressionLeadingToEvalResult contains control logic
-Auxiliary function for converting EvalResult to readable strings

Refactored ast_test.cc to use raw protos instead of lexer and parser
