### PR TITLE
[p4 constraints] Updated ast_constructor/parser `::` is properly captured when quoting metadata access

### DIFF
--- a/e2e_tests/invalid_constraints.expected.output
+++ b/e2e_tests/invalid_constraints.expected.output
@@ -68,8 +68,8 @@ Type error: expected type bool, got int
    |     ^^^^^^^^^^^^^^^^^
 Type error: operand type optional<32> does not support ordered comparison
 
-- e2e_tests/invalid_constraints.p4:102:7-13:
+- e2e_tests/invalid_constraints.p4:102:5-13:
     |   @entry_restriction("
 102 |     ::unknown > 10;
-    |       ^^^^^^^
+    |     ^^^^^^^^^
 Type error: unknown metadata 'unknown'

--- a/e2e_tests/valid_constraints.expected.output
+++ b/e2e_tests/valid_constraints.expected.output
@@ -57,10 +57,10 @@ e2e_tests/table_entries/optional_match_table_valid_max_priority.pb.txt
 === Output ===
 All entries must satisfy:
 
-e2e_tests/valid_constraints.p4:64:7-27:
+e2e_tests/valid_constraints.p4:64:5-27:
    |     // A constraint on metadata.
 64 |     ::priority < 0x7fffffff;
-   |       ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
 >>>Entry Info<<<

--- a/p4_constraints/frontend/ast_constructors.cc
+++ b/p4_constraints/frontend/ast_constructors.cc
@@ -150,8 +150,9 @@ absl::StatusOr<ast::Expression> MakeKey(absl::Span<const Token> key_fragments) {
   return ast;
 }
 
-absl::StatusOr<ast::Expression> MakeMetadataAccess(const Token& metadata_name) {
-  ast::Expression ast = LocatedExpression(metadata_name.start_location,
+absl::StatusOr<ast::Expression> MakeMetadataAccess(const Token& double_colon,
+                                                   const Token& metadata_name) {
+  ast::Expression ast = LocatedExpression(double_colon.start_location,
                                           metadata_name.end_location);
   ast.mutable_metadata_access()->set_metadata_name(metadata_name.text);
   return ast;

--- a/p4_constraints/frontend/ast_constructors.h
+++ b/p4_constraints/frontend/ast_constructors.h
@@ -36,7 +36,8 @@ absl::StatusOr<ast::Expression> MakeBooleanConstant(const Token& boolean);
 absl::StatusOr<ast::Expression> MakeIntegerConstant(const Token& numeral);
 
 // Returns an AST for table entry metadata access (such as ::priority).
-absl::StatusOr<ast::Expression> MakeMetadataAccess(const Token& metadata_name);
+absl::StatusOr<ast::Expression> MakeMetadataAccess(const Token& double_colon,
+                                                   const Token& metadata_name);
 
 // Returns an AST `a` such that `a.key() == "id1.id2...idn"` if given ID tokens
 // `{t1, ..., tn}` such that `idi == ti.text`, or an error Status otherwise.

--- a/p4_constraints/frontend/parser.cc
+++ b/p4_constraints/frontend/parser.cc
@@ -238,7 +238,7 @@ absl::StatusOr<Expression> ParseConstraintAbove(int context_precedence,
     case Token::DOUBLE_COLON: {
       ASSIGN_OR_RETURN(const Token metadata_name,
                        ExpectTokenKind(Token::ID, tokens));
-      ASSIGN_OR_RETURN(ast, ast::MakeMetadataAccess(metadata_name));
+      ASSIGN_OR_RETURN(ast, ast::MakeMetadataAccess(token, metadata_name));
       break;
     }
     case Token::BANG: {


### PR DESCRIPTION
[p4 constraints] Updated ast_constructor/parser `::` is properly captured when quoting metadata access
