### PR TITLE
[p4-constraints] Improve failure explanation by only referencing relevant keys.

### DIFF
--- a/e2e_tests/valid_constraints.expected.output
+++ b/e2e_tests/valid_constraints.expected.output
@@ -16,17 +16,10 @@ e2e_tests/valid_constraints.p4:22:5-65:
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "valid_constraints.vrf_classifier_table"
 Priority:0
-Key:"hdr.ethernet.ether_type" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"hdr.ethernet.src_addr" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"hdr.ipv4.dst_addr" -> Value: Ternary{.value = 3224115, .mask = 3224115}
-Key:"hdr.ipv4.src_addr" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"hdr.ipv6.dst_addr" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"local_metadata.dscp" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"local_metadata.is_ip_packet" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"standard_metadata.ingress_port" -> Value: Ternary{.value = 0, .mask = 0}
+Field: "hdr.ipv4.dst_addr" -> Value: Ternary{.value = 3224115, .mask = 3224115}
 
 ### P4Constraints Table Entry Test #######################
 === Input Table Entry File ===
@@ -40,10 +33,10 @@ e2e_tests/valid_constraints.p4:62:5-32:
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "valid_constraints.optional_match_table"
 Priority:0
-Key:"hdr.ipv4.dst_addr" -> Value: Ternary{.value = 3224115, .mask = 4294967295}
+Field: "hdr.ipv4.dst_addr" -> Value: Ternary{.value = 3224115, .mask = 4294967295}
 
 ### P4Constraints Table Entry Test #######################
 === Input Table Entry File ===
@@ -63,10 +56,9 @@ e2e_tests/valid_constraints.p4:64:5-27:
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "valid_constraints.optional_match_table"
 Priority:2147483647
-Key:"hdr.ipv4.dst_addr" -> Value: Ternary{.value = 0, .mask = 0}
 
 ### P4Constraints Table Entry Test #######################
 === Input Table Entry File ===
@@ -79,10 +71,9 @@ e2e_tests/valid_constraints.p4:14:1-5:
    | ^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "valid_constraints.reject_all_entries"
 Priority:0
-
 
 ### P4Constraints Table Entry Test #######################
 === Input Table Entry File ===

--- a/p4_constraints/BUILD.bazel
+++ b/p4_constraints/BUILD.bazel
@@ -15,6 +15,7 @@ cc_library(
         "//gutils:status",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",

--- a/p4_constraints/ast.h
+++ b/p4_constraints/ast.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 #include "p4_constraints/ast.pb.h"
@@ -62,6 +63,9 @@ bool SetTypeBitwidth(Type* type, int bitwidth);
 Type TypeCaseToType(Type::TypeCase type_case);
 
 // -- Utility ------------------------------------------------------------------
+
+// Returns a set containing the `fields` present in `expr`.
+absl::flat_hash_set<std::string> GetMatchFields(const ast::Expression& expr);
 
 // Cache for results of `Size`.
 using SizeCache = absl::flat_hash_map<const Expression*, int>;

--- a/p4_constraints/backend/BUILD.bazel
+++ b/p4_constraints/backend/BUILD.bazel
@@ -26,6 +26,7 @@ cc_library(
         "@com_github_google_glog//:glog",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",

--- a/p4_constraints/backend/interpreter_golden_test_runner.expected
+++ b/p4_constraints/backend/interpreter_golden_test_runner.expected
@@ -51,14 +51,10 @@ In @entry_restriction of table 'golden_table'; at offset line 1, columns 23 to 4
   |                       ^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+Field: "exact32" -> Value: Exact{.value = 10}
 
 ### ReasonEntryViolatestConstraint Test ###################
 === INPUT ===
@@ -84,14 +80,10 @@ In @entry_restriction of table 'golden_table'; at offset line 3, columns 1 to 20
   | ^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+Field: "exact32" -> Value: Exact{.value = 10}
 
 ### ReasonEntryViolatestConstraint Test ###################
 === INPUT ===
@@ -117,14 +109,10 @@ golden_test.p4:3:1-19:
   | ^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+Field: "exact32" -> Value: Exact{.value = 10}
 
 ### ReasonEntryViolatestConstraint Test ###################
 === INPUT ===
@@ -150,14 +138,10 @@ golden_test.p4:3:1-43:
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+Field: "exact32" -> Value: Exact{.value = 10}
 
 ### ReasonEntryViolatestConstraint Test ###################
 === INPUT ===
@@ -183,14 +167,10 @@ golden_test.p4:2:27-46:
   |                           ^^^^^^^^^^^^^^^^^^^^
 
 But your entry does.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
+Field: "exact32" -> Value: Exact{.value = 10}
 
 ### ReasonEntryViolatestConstraint Test ###################
 === INPUT ===
@@ -215,14 +195,10 @@ In @entry_restriction of table 'golden_table'; at offset line 2, columns 1 to 22
   | ^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 42, .mask = 64}
+Field: "ternary32" -> Value: Ternary{.value = 42, .mask = 64}
 
 ### ReasonEntryViolatestConstraint Test ###################
 === INPUT ===
@@ -245,12 +221,7 @@ golden_test.p4:1:32-35:
   |                                ^^^^
 
 But your entry does.
->>>Entry Info<<<
+>>>Relevant Entry Info<<<
 Table Name: "golden_table"
 Priority:0
-Key:"exact32" -> Value: Exact{.value = 10}
-Key:"lpm32" -> Value: Lpm{.value = 0, .prefix_length = 0}
-Key:"optional32" -> Value: Ternary{.value = 0, .mask = 0}
-Key:"range32" -> Value: Range{.low = 0, .high = 4294967295}
-Key:"ternary32" -> Value: Ternary{.value = 0, .mask = 0}
 


### PR DESCRIPTION
[p4-constraints] Improve failure explanation by only referencing relevant keys.

Also, in explanation output, changed `key` to `field` to be more accurate.
