### PR TITLE
Refactor Typechecker to use QuoteSubConstraint instead of QuoteSourceLocation

### DIFF
--- a/e2e_tests/invalid_constraints.expected.output
+++ b/e2e_tests/invalid_constraints.expected.output
@@ -15,12 +15,14 @@ Parse error: unexpected token: <END_OF_INPUT>. Expected true, false, <BINARY>, <
 Parse error: unexpected token: <END_OF_INPUT>. Expected true, false, <BINARY>, <OCTARY>, <DECIMAL>, <HEXADEC>, <ID>, ::, !, -, or (.
 
 - e2e_tests/invalid_constraints.p4:27:5-15:
-   |   @entry_restriction("
+   | 
 27 |     foo.bar.baz == 2
    |     ^^^^^^^^^^^
 Type error: unknown key foo.bar.baz
 
 - In @entry_restriction of table 'invalid_constraints.unknown_key_no_srcloc'; at offset line 1, columns 1 to 11:
+1 | foo.bar.baz == 2
+  | ^^^^^^^^^^^
 Type error: unknown key foo.bar.baz
 
 - e2e_tests/invalid_constraints.p4:38:21-22:
@@ -38,38 +40,38 @@ Parse error: unexpected token: <ID>. Expected <END_OF_INPUT>, ), ::, &&, ;, ||, 
    |           ^^^^
 Parse error: unexpected token: <ID>. Expected <END_OF_INPUT>, ), ::, &&, ;, ||, ->, ==, !=, >, >=, <, or <=.
 
-- e2e_tests/invalid_constraints.p4:60:5-15:
-   |   @entry_restriction("
+- e2e_tests/invalid_constraints.p4:60:5-30:
+   | 
 60 |     ternary_key::prefix_length
-   |     ^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Type error: expression of type ternary<32> has no field 'prefix_length'
 
-- e2e_tests/invalid_constraints.p4:70:5-10:
-   |   @entry_restriction("
+- e2e_tests/invalid_constraints.p4:70:5-19:
+   | 
 70 |     0x0F0F :: value
-   |     ^^^^^^
+   |     ^^^^^^^^^^^^^^^
 Type error: expression of type int has no field 'value'
 
 - e2e_tests/invalid_constraints.p4:77:42-46:
-   |   @entry_restriction("
+   | 
 77 |     -0x0F0F == -0o01234567 -> !false && -false
    |                                          ^^^^^
 Type error: expected type int, got bool
 
 - e2e_tests/invalid_constraints.p4:84:33:
-   |   @entry_restriction("
+   | 
 84 |     !false -> -8 == -0b1000 || !1
    |                                 ^
 Type error: expected type bool, got int
 
 - e2e_tests/invalid_constraints.p4:92:5-21:
-   |   @entry_restriction("
+   | 
 92 |     optional_key > 10;
    |     ^^^^^^^^^^^^^^^^^
 Type error: operand type optional<32> does not support ordered comparison
 
 - e2e_tests/invalid_constraints.p4:102:5-13:
-    |   @entry_restriction("
+    | 
 102 |     ::unknown > 10;
     |     ^^^^^^^^^
 Type error: unknown metadata 'unknown'

--- a/p4_constraints/backend/BUILD.bazel
+++ b/p4_constraints/backend/BUILD.bazel
@@ -126,6 +126,7 @@ cc_test(
         "//gutils:status_matchers",
         "//p4_constraints:ast",
         "//p4_constraints:ast_cc_proto",
+        "//p4_constraints:constraint_source",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/p4_constraints/backend/type_checker.h
+++ b/p4_constraints/backend/type_checker.h
@@ -28,7 +28,7 @@ namespace p4_constraints {
 // Type checks the given expression, returning an OkStatus if type checking
 // succeeds or an InvalidInput Status otherwise.
 //
-// Note that this is a side-effecting operation that may mutates the given
+// Note that this is a side-effecting operation that may mutate the given
 // expression in two ways:
 // - It may mutate the type of the expression and its subexpressions, filling in
 //   the correct types.
@@ -37,9 +37,9 @@ namespace p4_constraints {
 // Upon successful completion of this function, the given expression is
 // guaranteed to contain no ast::Type::Unknown/Unsupported types.
 //
-// This function is idempotent, meaning that if it is called twice in a row,
-// the function returns the same result each time and does not further mutate
-// its input during the second call.
+// This function should not be called on an `expr` that has already been type
+// checked (more specifically, on an `expr` that already contains type casts).
+// Doing so will reult in an InvalidInput Error.
 absl::Status InferAndCheckTypes(ast::Expression* expr,
                                 const TableInfo& table_info);
 


### PR DESCRIPTION
Refactor Typechecker to use QuoteSubConstraint instead of QuoteSourceLocation
