### PR TITLE
Change Tokenize input to ConstraintSource instead of string and location.

### DIFF
--- a/p4_constraints/backend/interpreter_golden_test_runner.cc
+++ b/p4_constraints/backend/interpreter_golden_test_runner.cc
@@ -76,9 +76,7 @@ absl::StatusOr<ConstraintInfo> MakeConstraintInfo(TestCase test_case) {
   }
 
   TableInfo table_info = kTableInfo;
-  ASSIGN_OR_RETURN(Expression expression,
-                   ParseConstraint(Tokenize(source.constraint_string,
-                                            source.constraint_location)));
+  ASSIGN_OR_RETURN(Expression expression, ParseConstraint(Tokenize(source)));
   CHECK_OK(InferAndCheckTypes(&(expression), kTableInfo));
   table_info.constraint = expression;
   table_info.constraint_source = source;

--- a/p4_constraints/frontend/BUILD.bazel
+++ b/p4_constraints/frontend/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
         ":token",
         "//p4_constraints:ast",
         "//p4_constraints:ast_cc_proto",
+        "//p4_constraints:constraint_source",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
         "@com_googlesource_code_re2//:re2",
@@ -57,6 +58,7 @@ cc_test(
         ":lexer",
         ":token",
         "//p4_constraints:ast_cc_proto",
+        "//p4_constraints:constraint_source",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/p4_constraints/frontend/lexer.cc
+++ b/p4_constraints/frontend/lexer.cc
@@ -22,6 +22,7 @@
 #include "glog/logging.h"
 #include "p4_constraints/ast.h"
 #include "p4_constraints/ast.pb.h"
+#include "p4_constraints/constraint_source.h"
 #include "p4_constraints/frontend/token.h"
 #include "re2/re2.h"
 
@@ -107,12 +108,13 @@ absl::string_view CaptureByName(
 
 }  // namespace
 
-std::vector<Token> Tokenize(absl::string_view input,
-                            ast::SourceLocation start_location) {
+std::vector<Token> Tokenize(const ConstraintSource& constraint) {
   // Output.
   std::vector<Token> tokens;
-
+  // Input
+  absl::string_view input = constraint.constraint_string;
   // Location tracking.
+  ast::SourceLocation start_location = constraint.constraint_location;
   ast::SourceLocation current_location = start_location;
 
   // +1 because there is an implicit capturing group at index 0 corresponding to

--- a/p4_constraints/frontend/lexer.h
+++ b/p4_constraints/frontend/lexer.h
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-// The lexer turns an input string into a sequence of tokens.
+// The lexer turns an input `ConstraintSource` into a
+// sequence of tokens.
 //
 // Known limitation: When the lexer returns an UNEXPECTED_CHAR token, the
 // location of that token points at the first character in a sequence of
@@ -39,16 +40,16 @@
 
 #include "absl/strings/string_view.h"
 #include "p4_constraints/ast.pb.h"
+#include "p4_constraints/constraint_source.h"
 #include "p4_constraints/frontend/token.h"
 
 namespace p4_constraints {
 
-// Turns the input string into a sequence of tokens. Note that this function
-// is total; syntax errors are signaled by emitting an UNEXPECTED_CHAR token.
-// The final token in the returned token sequence is guaranteed to be an
+// Turns the input `constraint` into a sequence of tokens. Note that this
+// function is total; syntax errors are signaled by emitting an UNEXPECTED_CHAR
+// token. The final token in the returned token sequence is guaranteed to be an
 // END_OF_INPUT or UNEXPECTED_CHAR token.
-std::vector<Token> Tokenize(absl::string_view input,
-                            ast::SourceLocation start_location);
+std::vector<Token> Tokenize(const ConstraintSource& constraint);
 
 }  // namespace p4_constraints
 

--- a/p4_constraints/frontend/lexer_test.cc
+++ b/p4_constraints/frontend/lexer_test.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "p4_constraints/ast.pb.h"
+#include "p4_constraints/constraint_source.h"
 #include "p4_constraints/frontend/token.h"
 
 namespace p4_constraints {
@@ -40,7 +41,11 @@ TEST(LexerTest, AllKeywordsAreRecognized) {
     std::string keyword = Token::KindToKeyword(kind);
     ASSERT_GT(keyword.size(), 0);
     if (keyword.front() == '<' && keyword.back() == '>') continue;
-    EXPECT_THAT(Tokenize(keyword, ast::SourceLocation()),
+    ConstraintSource source{
+        .constraint_string = keyword,
+        .constraint_location = ast::SourceLocation(),
+    };
+    EXPECT_THAT(Tokenize(source),
                 ElementsAre(Field(&Token::kind, Eq(kind)),
                             Field(&Token::kind, Eq(Token::END_OF_INPUT))));
     keyword_kinds.push_back(kind);
@@ -51,7 +56,11 @@ TEST(LexerTest, AllKeywordsAreRecognized) {
   for (Token::Kind kind : keyword_kinds) {
     input << kind << " ";
   }
-  auto tokens = Tokenize(input.str(), ast::SourceLocation());
+  ConstraintSource source{
+      .constraint_string = input.str(),
+      .constraint_location = ast::SourceLocation(),
+  };
+  auto tokens = Tokenize(source);
   ASSERT_THAT(tokens.size(), keyword_kinds.size() + 1);
   EXPECT_THAT(tokens.back(), Field(&Token::kind, Eq(Token::END_OF_INPUT)));
   for (int i = 0; i < keyword_kinds.size(); i++) {
@@ -184,7 +193,11 @@ TEST(LexerTest, PositiveSingleToken) {
   for (const auto& test : tests) {
     const auto& str = test.first;
     const auto& expected_tokens = test.second;
-    auto actual_tokens = Tokenize(str, ast::SourceLocation());
+    ConstraintSource source{
+        .constraint_string = str,
+        .constraint_location = ast::SourceLocation(),
+    };
+    auto actual_tokens = Tokenize(source);
     for (int i = 0; i < expected_tokens.size(); ++i) {
       EXPECT_EQ(actual_tokens[i].kind, expected_tokens[i])
           << "[!] Token " << (i + 1) << " in '" << str << "' unexpected.\n"
@@ -236,7 +249,11 @@ TEST(LexerTest, NegativeToken) {
   for (const auto& test : tests) {
     const auto& str = test.first;
     const auto& bad_token = test.second;
-    auto tokens = Tokenize(str, ast::SourceLocation());
+    ConstraintSource source{
+        .constraint_string = str,
+        .constraint_location = ast::SourceLocation(),
+    };
+    auto tokens = Tokenize(source);
     EXPECT_NE(tokens[0].kind, bad_token)
         << "[!] String \"" << str << "\" incorrectly lexed as token"
         << bad_token << ".\n";
@@ -260,7 +277,11 @@ TEST(LexerTest, CommentsAreLexedCorrectly) {
   for (const auto& test : tests) {
     const auto& str = test.first;
     const auto& expected_tokens = test.second;
-    auto actual_tokens = Tokenize(str, ast::SourceLocation());
+    ConstraintSource source{
+        .constraint_string = str,
+        .constraint_location = ast::SourceLocation(),
+    };
+    auto actual_tokens = Tokenize(source);
     for (int i = 0; i < expected_tokens.size(); ++i) {
       EXPECT_EQ(actual_tokens[i].kind, expected_tokens[i])
           << "[!] Token " << (i + 1) << " in '" << str << "' unexpected.\n"


### PR DESCRIPTION
Change Tokenize input to ConstraintSource instead of string and location.
