### PR TITLE
Add section on well-formedness constraints and their connection to P4Runtime to the language spec

### DIFF
--- a/docs/language-specification.md
+++ b/docs/language-specification.md
@@ -100,7 +100,7 @@ These well-formedness constraints are shown in the table above and essentially
 say that the entries are valid [according to the P4Runtime standard].
 This includes *canonicity constraints* that rule out distinct but semanitcally
 equivalent representations of table entries. For example, using
-[P4's mask notation], the ternaries `10 &&& 10` and `11 &&& 11` are equivalent,
+[P4's mask notation], the ternaries `10 &&& 10` and `11 &&& 10` are equivalent,
 as both match the set of bitvectors `{10, 11}`. But only `10 &&& 10` is legal
 [according to the P4Runtime standard], which says that  masked-off bits must be
 0. In general, this is captured by the constraint `value & !mask == 0`.

--- a/docs/language-specification.md
+++ b/docs/language-specification.md
@@ -74,7 +74,7 @@ table:
 | ternary      | k::value         | bit\<W\>   | masked-off bits are zero: `value & !mask == 0`
 |              | k::mask          | bit\<W\>   |
 | optional     | k::value         | bit\<W\>   | masked-off bits are zero: `value & !mask == 0` 
-|              | k::mask          | bit\<W\>   | wildcad or exact match: `mask == -1 \|\| mask == 0`
+|              | k::mask          | bit\<W\>   | wildcard or exact match: `mask == -1 \|\| mask == 0`
 | lpm          | k::value         | bit\<W\>   | masked-off bits are zero:`value & !prefix_mask == 0`<br> where `prefix_mask` is a `W`-bit vector whose upper `prefix_length` bits are 1 and the lower bits are 0
 |              | k::prefix_length | int        | `0 <= prefix_length && prefix_length <= W` 
 | range        | k::low           | bit\<W\>   | `low < high \|\| (low == 0 & high == 0)`

--- a/docs/language-specification.md
+++ b/docs/language-specification.md
@@ -82,7 +82,7 @@ table:
 
 Note that an `optional` match is just a restricted kind of `ternary` match whose mask always satisfies the following constraint:
 ```
-// Wildcard match or wildcard match.
+// Wildcard match or exact match.
 optional_match_key::mask == 0 || optional_match_key::mask == -1
 ```
 
@@ -98,7 +98,7 @@ In p4-constraints, we assume that all table entries we consider satisify certain
 `@entry_restriction`.
 These well-formedness constraints are shown in the table above and essentially
 say that the entries are valid [according to the P4Runtime standard].
-This includes *canonicity constraints* that rule out distinct but semanitcally
+This includes *canonicity constraints* that rule out distinct but semantically
 equivalent representations of table entries. For example, using
 [P4's mask notation], the ternaries `10 &&& 10` and `11 &&& 10` are equivalent,
 as both match the set of bitvectors `{10, 11}`. But only `10 &&& 10` is legal


### PR DESCRIPTION
@jonathan-dilorenzo PTAL.

FYI, we should also update the section on "metdata" in case we rename it.