### PR TITLE
Add an API to get TableInfo from ConstraintInfo through a lookup using table_id

### DIFF
--- a/p4_constraints/backend/constraint_info.cc
+++ b/p4_constraints/backend/constraint_info.cc
@@ -188,6 +188,13 @@ std::optional<AttributeInfo> GetAttributeInfo(
   return absl::nullopt;
 }
 
+const TableInfo* GetTableInfoOrNull(const ConstraintInfo& constraint_info,
+                                    uint32_t table_id) {
+  auto it = constraint_info.find(table_id);
+  if (it == constraint_info.end()) return nullptr;
+  return &it->second;
+}
+
 absl::StatusOr<ConstraintInfo> P4ToConstraintInfo(
     const p4::config::v1::P4Info& p4info) {
   // Allocate output.

--- a/p4_constraints/backend/constraint_info.h
+++ b/p4_constraints/backend/constraint_info.h
@@ -83,6 +83,11 @@ using ConstraintInfo = absl::flat_hash_map<uint32_t, TableInfo>;
 absl::StatusOr<ConstraintInfo> P4ToConstraintInfo(
     const p4::config::v1::P4Info& p4info);
 
+// Returns a unique pointer to the TableInfo associated with a given table_id
+// or std::nullptr if the table_id cannot be found.
+const TableInfo* GetTableInfoOrNull(const ConstraintInfo& constraint_info,
+                                    uint32_t table_id);
+
 // Table entry attribute accessible in the constraint language, e.g. priority.
 struct AttributeInfo {
   std::string name;


### PR DESCRIPTION
Add an API to get TableInfo from ConstraintInfo through a lookup using table_id.

This is part of a larger effort to not expose p4-constraints internals to clients, so we can change internals without breaking clients.