### PR TITLE
Refactor ConstraintInfo into a struct containing a map from table_id to table_info and a map from action_id to action_info.

### DIFF
--- a/p4_constraints/backend/BUILD.bazel
+++ b/p4_constraints/backend/BUILD.bazel
@@ -50,7 +50,6 @@ cc_test(
         ":constraint_info",
         ":interpreter",
         "//gutils:parse_text_proto",
-        "//gutils:status",
         "//gutils:status_matchers",
         "//p4_constraints:ast",
         "//p4_constraints:ast_cc_proto",

--- a/p4_constraints/backend/constraint_info.h
+++ b/p4_constraints/backend/constraint_info.h
@@ -71,9 +71,24 @@ struct TableInfo {
   absl::flat_hash_map<std::string, KeyInfo> keys_by_name;
 };
 
+struct ActionInfo {
+  uint32_t id;       // Same as Action.preamble.id in p4info.proto.
+  std::string name;  // Same as Action.preamble.name in p4info.proto.
+
+  // An optional constraint (aka action_restriction) on actions.
+  absl::optional<ast::Expression> constraint;
+  // If member `constraint` is present, this captures its source. Arbitrary
+  // otherwise.
+  ConstraintSource constraint_source;
+};
+
 // Contains all information required for constraint checking.
-// Technically, a map from table IDs to TableInfo.
-using ConstraintInfo = absl::flat_hash_map<uint32_t, TableInfo>;
+struct ConstraintInfo {
+  // Maps from action IDs to ActionInfo.
+  absl::flat_hash_map<uint32_t, ActionInfo> action_info_by_id;
+  // Maps from table IDs to TableInfo.
+  absl::flat_hash_map<uint32_t, TableInfo> table_info_by_id;
+};
 
 // Translates P4Info to ConstraintInfo.
 //

--- a/p4_constraints/backend/interpreter_test.cc
+++ b/p4_constraints/backend/interpreter_test.cc
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 #include <stdint.h>
 
-#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -32,7 +31,6 @@
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "gutils/parse_text_proto.h"
-#include "gutils/status_macros.h"
 #include "gutils/status_matchers.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "p4_constraints/ast.h"
@@ -129,7 +127,13 @@ class EntryMeetsConstraintTest : public ::testing::Test {
     table_info.constraint = expr;
     table_info.constraint_source.constraint_location.set_table_name(
         table_info.name);
-    return {{table_info.id, table_info}};
+    return {
+        .action_info_by_id = {},
+        .table_info_by_id = {{
+            table_info.id,
+            table_info,
+        }},
+    };
   }
 
   static Expression ExpressionWithType(const Type& type,

--- a/p4_constraints/backend/symbolic_interpreter_test.cc
+++ b/p4_constraints/backend/symbolic_interpreter_test.cc
@@ -628,7 +628,13 @@ TEST_P(ConstraintTest, ConcretizeEntryGivesEntrySatisfyingConstraints) {
     }
   }
 
-  ConstraintInfo context{{table_info.id, table_info}};
+  ConstraintInfo context{
+      .action_info_by_id = {},
+      .table_info_by_id = {{
+          table_info.id,
+          table_info,
+      }},
+  };
   // The empty string signifies that the entry doesn't violate the constraint.
   EXPECT_THAT(ReasonEntryViolatesConstraint(concretized_entry, context),
               IsOkAndHolds(""))
@@ -707,7 +713,13 @@ TEST_P(ConstraintTest, EncodeValidTableEntryInZ3AndConcretizeEntry) {
       ConcretizeEntry(solver.get_model(), table_info, environment));
 
   // The empty string signifies that the entry doesn't violate the constraint.
-  ConstraintInfo context{{table_info.id, table_info}};
+  ConstraintInfo context{
+      .action_info_by_id = {},
+      .table_info_by_id = {{
+          table_info.id,
+          table_info,
+      }},
+  };
   EXPECT_THAT(ReasonEntryViolatesConstraint(concretized_entry, context),
               IsOkAndHolds(""))
       << "\nFor entry:\n"
@@ -837,7 +849,13 @@ TEST_P(FullySpecifiedConstraintTest, ConcretizeEntryGivesExactEntry) {
 
   TableInfo table_info =
       GetTableInfoWithConstraint(GetParam().constraint_string);
-  ConstraintInfo context{{table_info.id, table_info}};
+  ConstraintInfo context{
+      .action_info_by_id = {},
+      .table_info_by_id = {{
+          table_info.id,
+          table_info,
+      }},
+  };
   // TODO(b/297400616): p4-constraints currently does not correctly translate
   // the bytestring representing 1280 to 1280 (instead turning it into 5).
   if (!absl::StrContains(GetParam().constraint_string, "1280")) {
@@ -890,7 +908,13 @@ TEST_P(FullySpecifiedConstraintTest,
 
   TableInfo table_info =
       GetTableInfoWithConstraint(GetParam().constraint_string);
-  ConstraintInfo context{{table_info.id, table_info}};
+  ConstraintInfo context{
+      .action_info_by_id = {},
+      .table_info_by_id = {{
+          table_info.id,
+          table_info,
+      }},
+  };
   // TODO(b/297400616): p4-constraints currently does not correctly translate
   // the bytestring representing 1280 to 1280 (instead turning it into 5).
   if (!absl::StrContains(GetParam().constraint_string, "1280")) {


### PR DESCRIPTION
Refactor ConstraintInfo into a struct containing a map from table_id to table_info and a map from action_id to action_info.

This is part of the work to support actions in P4-constraints by allowing users to add constraint annotations for actions. Please see the design doc at https://docs.google.com/document/d/11Nkn3_BAa43OX4I-_DPsoUokebGdRYx6QAk7eGVAyLc/edit?resourcekey=0-gO31LvkRyylb07KB1m3RMg for more information.

PUBLIC: [p4-fuzzer] Update tests to be compatible with latest p4-constraints
