### PR TITLE
PUBLIC: [p4-constraints] Cleanup existing code in p4-constraints constraint_info and interpreter.

### DIFF
--- a/p4_constraints/backend/constraint_info.cc
+++ b/p4_constraints/backend/constraint_info.cc
@@ -304,6 +304,13 @@ const TableInfo* GetTableInfoOrNull(const ConstraintInfo& constraint_info,
   return &it->second;
 }
 
+const ActionInfo* GetActionInfoOrNull(const ConstraintInfo& constraint_info,
+                                      uint32_t action_id) {
+  auto it = constraint_info.action_info_by_id.find(action_id);
+  if (it == constraint_info.action_info_by_id.end()) return nullptr;
+  return &it->second;
+}
+
 absl::StatusOr<ConstraintInfo> P4ToConstraintInfo(
     const p4::config::v1::P4Info& p4info) {
   // Allocate output.

--- a/p4_constraints/backend/constraint_info_test.cc
+++ b/p4_constraints/backend/constraint_info_test.cc
@@ -30,7 +30,11 @@ TEST(P4ToConstraintInfoTest, ValidActionRestrictionSucceeds) {
         alias: "act_1"
         annotations: "@action_restriction(\"multicast_group_id != 0\")"
       }
-      params { id: 1 name: "multicast_group_id" bitwidth: 16 }
+      params {
+        id: 1
+        name: "multicast_group_id"
+        bitwidth: 16,
+      }
     }
       )pb";
 
@@ -104,6 +108,46 @@ Syntax error: @action_restriction must be enclosed in '("' and '")'
       constraints.status().message());
 
   ASSERT_TRUE(!constraints.status().ok());
+}
+
+TEST(GetTableInfoOrNullTest, ShouldGetNonNullptrToTableInfo) {
+  P4Info p4_info;
+
+  ASSERT_OK(gutils::ReadProtoFromString(R"pb(
+                                          tables {
+                                            preamble {
+                                              id: 1
+                                              name: "table",
+                                            }
+                                          }
+                                        )pb",
+                                        &p4_info));
+
+  ASSERT_OK_AND_ASSIGN(ConstraintInfo constraints,
+                       p4_constraints::P4ToConstraintInfo(p4_info));
+
+  ASSERT_NE(GetTableInfoOrNull(constraints, 1), nullptr);
+}
+
+TEST(GetActionInfoOrNullTest, ShouldGetNonNullptrToActionInfo) {
+  P4Info p4_info;
+
+  ASSERT_OK(gutils::ReadProtoFromString(
+      R"pb(
+        actions {
+          preamble {
+            id: 123
+            name: "MyIngress.act_1"
+            alias: "act_1",
+          }
+        }
+      )pb",
+      &p4_info));
+
+  ASSERT_OK_AND_ASSIGN(ConstraintInfo constraints,
+                       p4_constraints::P4ToConstraintInfo(p4_info));
+
+  ASSERT_NE(GetActionInfoOrNull(constraints, 123), nullptr);
 }
 
 }  // namespace p4_constraints

--- a/p4_constraints/backend/interpreter.cc
+++ b/p4_constraints/backend/interpreter.cc
@@ -200,7 +200,7 @@ absl::StatusOr<TableEntry> ParseEntry(const p4::v1::TableEntry& entry,
   }
 
   // Use default value for omitted keys.
-  // See Section 9.1.1. of the P4runtime specification.
+  // See Section 9.1.1. of the P4Runtime specification.
   for (const auto& [name, key_info] : table_info.keys_by_name) {
     if (keys.contains(name)) continue;
     switch (key_info.type.type_case()) {
@@ -523,7 +523,7 @@ absl::StatusOr<const Expression*> MinimalSubexpressionLeadingToEvalResult(
                 *candidate_subexpressions[0], context, eval_cache, size_cache);
           }
           // Returns the `MinimalSubexpressionLeadingToEvalResult` from the
-          // candidate who has the smallest such subexpresson.
+          // candidate who has the smallest such subexpression.
           ASSIGN_OR_RETURN(auto* subexpression_0,
                            MinimalSubexpressionLeadingToEvalResult(
                                *candidate_subexpressions[0], context,
@@ -616,10 +616,10 @@ absl::StatusOr<EvalResult> Eval_(const Expression& expr,
     case Expression::kKey: {
       auto it = context.entry.keys.find(expr.key());
       if (it == context.entry.keys.end()) {
-        RuntimeTypeError(context.source, expr.start_location(),
-                         expr.end_location())
-            << "unknown key " << expr.key() << " in table "
-            << context.entry.table_name;
+        return RuntimeTypeError(context.source, expr.start_location(),
+                                expr.end_location())
+               << "unknown key " << expr.key() << " in table "
+               << context.entry.table_name;
       }
       return it->second;
     }


### PR DESCRIPTION
PUBLIC: [p4-constraints] Cleanup existing code in p4-constraints constraint_info and interpreter.

Small fixes to existing code that include formatting changes, adding tests for existing methods, adding a method definition with an existing declaration, returning an error when previously no error was returned, and fixing spelling mistakes in comments. The definition of GetActionInfoOrNull is added since the declaration for GetActionInfoOrNull already exists in the header file but was was not added in a previous CL.
