### PR TITLE
PUBLIC: [p4-constraints] Expose and change the return of ParseP4RTInteger from StatusOr<Integer> to Integer.

### DIFF
--- a/p4_constraints/backend/interpreter.h
+++ b/p4_constraints/backend/interpreter.h
@@ -207,6 +207,11 @@ absl::StatusOr<bool> EvalToBool(const ast::Expression& expr,
                                 const EvaluationContext& context,
                                 EvaluationCache* eval_cache);
 
+// Converts a P4 integer in binary string format to Integer format. For details
+// on the conversion, see
+// https://p4.org/p4-spec/docs/p4runtime-spec-working-draft-html-version.html#sec-bytestrings.
+Integer ParseP4RTInteger(std::string int_str);
+
 }  // namespace internal_interpreter
 }  // namespace p4_constraints
 

--- a/p4_constraints/backend/interpreter_test.cc
+++ b/p4_constraints/backend/interpreter_test.cc
@@ -929,6 +929,13 @@ TEST_F(MinimalSubexpressionLeadingToEvalResultTest,
   EXPECT_THAT(MinimalSubexpressionLeadingToEvalResultHelper(kConstraint),
               IsOkAndHolds(Eq(&kConstraint)));
 }
+
+TEST(ParseP4RTInteger, ParsesZeroCorrectly) {
+  auto zero_string = std::string(1, '\0');
+  ASSERT_EQ(zero_string.size(), 1);
+  ASSERT_EQ(zero_string.at(0), '\0');
+  EXPECT_THAT(ParseP4RTInteger(zero_string), Eq(0));
+}
 }  // namespace
 }  // namespace internal_interpreter
 }  // namespace p4_constraints


### PR DESCRIPTION
PUBLIC: [p4-constraints] Expose and change the return of ParseP4RTInteger from StatusOr<Integer> to Integer.

Since ParseP4RTInteger cannot return an error, we modified ParseP4RTInteger to return Integer instead of StatusOr<Integer>. We made ParseP4RTInteger public so that we can add a test for ParseP4RTInteger.
