### PR TITLE
PUBLIC: [p4-constraints] Remove EntryMeetsConstraint and replace with ReasonEntryViolatesConstraint in tests.

### DIFF
--- a/p4_constraints/backend/interpreter.h
+++ b/p4_constraints/backend/interpreter.h
@@ -47,14 +47,6 @@ namespace p4_constraints {
 absl::StatusOr<std::string> ReasonEntryViolatesConstraint(
     const p4::v1::TableEntry& entry, const ConstraintInfo& context);
 
-// Checks if a given table entry satisfies the entry constraint attached to its
-// associated table. Returns true if this is the case or if no constraint
-// exists. Returns an InvalidArgument Status if the entry belongs to a table not
-// present in ConstraintInfo, or if it is inconsistent with the table definition
-// in ConstraintInfo.
-absl::StatusOr<bool> EntryMeetsConstraint(const p4::v1::TableEntry& entry,
-                                          const ConstraintInfo& context);
-
 // -- END OF PUBLIC INTERFACE --------------------------------------------------
 
 // Exposed for testing only.


### PR DESCRIPTION
PUBLIC: [p4-constraints] Remove EntryMeetsConstraint and replace with ReasonEntryViolatesConstraint in tests.

EntryMeetsConstraint and ReasonEntryViolatesConstraint share common code. It was decided that we should keep ReasonEntryViolatesConstraint as it provides output that explains why an entry violated a constraint, whereas EntryMeetsConstraint does not. Tests were changed accordingly to use ReasonEntryViolatesConstraint. Documentation for https://github.com/p4lang/p4-constraints has been updated in another CL.
