### PR TITLE
[P4 Constraints Network Address Notation] Update Lexer to tokenize strings. Wrote unit test for the Lexer to tokenize IPV4 address

### DIFF
--- a/p4_constraints/frontend/lexer.cc
+++ b/p4_constraints/frontend/lexer.cc
@@ -92,6 +92,8 @@ const LazyRE2 kTokenPattern{
     "|(?:0[oO])" "(?P<octary>[0-7]+)"
     "|(?:0[xX])" "(?P<hexadec>[0-9a-fA-F]+)"
     "|(?:0[dD])?" "(?P<decimal>[0-9]+)"
+    // Strings.
+    "|(?P<string>\"([^\"]*)\")"
     // clang-format on
 };
 
@@ -178,6 +180,11 @@ std::vector<Token> Tokenize(const ConstraintSource& constraint) {
       // Update lexeme to exclude base prefix.
       lexeme = std::string(CaptureByName("hexadec", captures));
       kind = Token::HEXADEC;
+    } else if (!CaptureByName("string", captures).empty()) {
+      lexeme = std::string(CaptureByName("string", captures));
+      // Update lexeme to exclude double quotation marks
+      lexeme = lexeme.substr(1, lexeme.size() - 2);
+      kind = Token::STRING;
     } else {
       LOG(ERROR) << "impossible: no capture group matched in string: "
                  << lexeme;

--- a/p4_constraints/frontend/token.cc
+++ b/p4_constraints/frontend/token.cc
@@ -25,7 +25,7 @@
 namespace p4_constraints {
 
 // All token kinds. Keep in sync with enum Kind in token.h.
-const Token::Kind Token::kAllKinds[25] = {
+const Token::Kind Token::kAllKinds[26] = {
     // clang-format off
   TRUE,
   FALSE,
@@ -50,6 +50,7 @@ const Token::Kind Token::kAllKinds[25] = {
   OCTARY,
   DECIMAL,
   HEXADEC,
+  STRING,
   END_OF_INPUT,
   UNEXPECTED_CHAR,
     // clang-format on
@@ -103,6 +104,8 @@ std::string Token::KindToKeyword(Token::Kind token_kind) {
       return "<DECIMAL>";
     case Token::HEXADEC:
       return "<HEXADEC>";
+    case Token::STRING:
+      return "<STRING>";
     case Token::END_OF_INPUT:
       return "<END_OF_INPUT>";
     case Token::UNEXPECTED_CHAR:

--- a/p4_constraints/frontend/token.h
+++ b/p4_constraints/frontend/token.h
@@ -55,12 +55,13 @@ struct Token {
     DECIMAL,         // decimal numeral: 0..9+ or 0[dD](0..9)+
     HEXADEC,         // hexadecimal numeral: 0[xX](0..9|[a-fA-F])+
     END_OF_INPUT,    // indicates that the end of the input was reached
+    STRING,          // double quote string: \"[^\"]*\"|
     UNEXPECTED_CHAR  // indicates that an unexpected character was encountered
     // Invariant: UNEXPECTED_CHAR must always be the last (maximum) kind.
   };
 
   // All token kinds. Keep in sync with enum Kind.
-  static const Kind kAllKinds[25];
+  static const Kind kAllKinds[26];
 
   Token(const Kind kind, const std::string text,
         const ast::SourceLocation start_location,


### PR DESCRIPTION
[P4 Constraints Network Address Notation] Update Lexer to tokenize strings. Wrote unit test for the Lexer to tokenize IPV4 address
