### PR TITLE
Remove uses of DebugString due to deprecation.

### DIFF
--- a/p4_constraints/backend/interpreter_test.cc
+++ b/p4_constraints/backend/interpreter_test.cc
@@ -54,6 +54,12 @@ using ::testing::Not;
 using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 
+std::string PrintTextProto(const google::protobuf::Message& message) {
+  std::string text;
+  google::protobuf::TextFormat::PrintToString(message, &text);
+  return text;
+}
+
 class ReasonEntryViolatesConstraintTest : public ::testing::Test {
  public:
   const Type kUnknown = ParseTextProtoOrDie<Type>("unknown {}");
@@ -845,8 +851,8 @@ TEST_F(EvalTest, BinaryExpression_BooleanArguments) {
     for (bool right : {true, false}) {
       Expression expr = ExpressionWithType(
           kBool, absl::Substitute("binary_expression { left {$0} right {$1} }",
-                                  boolean(left).DebugString(),
-                                  boolean(right).DebugString()));
+                                  PrintTextProto(boolean(left)),
+                                  PrintTextProto(boolean(right))));
       EvalResult result;
 
       expr.mutable_binary_expression()->set_binop(ast::AND);
@@ -900,8 +906,8 @@ TEST_F(EvalTest, BinaryExpression_NumericArguments) {
     for (const Integer& right : values) {
       Expression expr = ExpressionWithType(
           kBool, absl::Substitute("binary_expression { left {$0} right {$1} }",
-                                  int_const(left).DebugString(),
-                                  int_const(right).DebugString()));
+                                  PrintTextProto(int_const(left)),
+                                  PrintTextProto(int_const(right))));
       EvalResult result;
 
       expr.mutable_binary_expression()->set_binop(ast::EQ);
@@ -947,7 +953,7 @@ TEST_F(EvalTest, BinaryExpression_CompositeArguments) {
   for (auto key : {"exact32", "ternary32", "lpm32", "range32"}) {
     Expression expr = ExpressionWithType(
         kBool, absl::Substitute("binary_expression { left {$0} right {$0} }",
-                                KeyExpr(key).DebugString()));
+                                PrintTextProto(KeyExpr(key))));
     EvalResult result;
 
     expr.mutable_binary_expression()->set_binop(ast::EQ);

--- a/p4_constraints/backend/type_checker_test.cc
+++ b/p4_constraints/backend/type_checker_test.cc
@@ -402,14 +402,16 @@ TEST_F(InferAndCheckTypesTest, BinaryBooleanOperators) {
     ASSERT_THAT(InferAndCheckTypes(&expr, kTableInfo), IsOk());
     EXPECT_TRUE(expr.type().has_boolean());
 
-    Expression nested = ParseTextProtoOrDie<Expression>(
-        absl::Substitute(R"pb(
-                           binary_expression {
-                             binop: $0
-                             left { $1 }
-                             right { $1 }
-                           })pb",
-                         op, expr.DebugString()));
+    std::string expr_textproto;
+    google::protobuf::TextFormat::PrintToString(expr, &expr_textproto);
+    Expression nested =
+        ParseTextProtoOrDie<Expression>(absl::Substitute(R"pb(
+                                                           binary_expression {
+                                                             binop: $0
+                                                             left { $1 }
+                                                             right { $1 }
+                                                           })pb",
+                                                         op, expr_textproto));
     Expression* right = expr.mutable_binary_expression()->mutable_right();
     std::swap(*right->mutable_binary_expression()->mutable_left(),
               *right->mutable_binary_expression()->mutable_right());


### PR DESCRIPTION
Migrate Protobuf DebugString calls due to the deprecation of that API.
