### PR TITLE
Make the constraint_kind header publicly accessible in the Bazel rules.

### DIFF
--- a/p4_constraints/frontend/BUILD.bazel
+++ b/p4_constraints/frontend/BUILD.bazel
@@ -121,8 +121,5 @@ cc_library(
 cc_library(
     name = "constraint_kind",
     hdrs = ["constraint_kind.h"],
-    visibility = [
-        "//p4_constraints/backend:__pkg__",
-        "@com_github_p4lang_p4c//:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
 )

--- a/p4_constraints/frontend/BUILD.bazel
+++ b/p4_constraints/frontend/BUILD.bazel
@@ -121,5 +121,8 @@ cc_library(
 cc_library(
     name = "constraint_kind",
     hdrs = ["constraint_kind.h"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//p4_constraints/backend:__pkg__",
+        "@com_github_p4lang_p4c//:__subpackages__",
+    ],
 )

--- a/p4_constraints/frontend/BUILD.bazel
+++ b/p4_constraints/frontend/BUILD.bazel
@@ -121,5 +121,5 @@ cc_library(
 cc_library(
     name = "constraint_kind",
     hdrs = ["constraint_kind.h"],
-    visibility = ["//p4_constraints/backend:__pkg__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
`parser.h` depends on `ConstraintKind` which is defined in `constraint_kind.h`. To please clang-tidy, one should include the `constraint_kind.h`. However that header is currently private. This PR makes it publicly available, like `parser.h`.