### PR TITLE
[p4-constraints] Allow C++ compliant multi-line strings.

### DIFF
--- a/e2e_tests/invalid_constraints.expected.output
+++ b/e2e_tests/invalid_constraints.expected.output
@@ -74,3 +74,15 @@ Type error: operand type optional<32> does not support ordered comparison
 102 |     ::unknown > 10;
     |     ^^^^^^^^^
 Type error: unknown attribute 'unknown'
+
+- e2e_tests/invalid_constraints.p4:113:1-9:
+    |       headers.ethernet.ether_type == 0x86DD;
+113 | ::unknown > 10;
+    | ^^^^^^^^^
+Type error: unknown attribute 'unknown'
+
+- e2e_tests/invalid_constraints.p4:157:5-13:
+    |     // An invalid constraint to ensure error messages are sensible.
+157 |     ::unknown > 10;
+    |     ^^^^^^^^^
+Type error: unknown attribute 'unknown'

--- a/e2e_tests/invalid_constraints.p4
+++ b/e2e_tests/invalid_constraints.p4
@@ -103,6 +103,77 @@ control invalid_constraints(inout headers_t headers,
   ")
   table unknown_metadata { actions = {} key = {} }
 
+  @file(__FILE__)
+  @line(__LINE__)
+  @entry_restriction(
+    // Either wildcard or exact match (i.e., "optional" match).
+    "headers.ipv4.dst_addr::mask == 0 || headers.ipv4.dst_addr::mask == -1;"
+
+    // Only match on IPv4 addresses of IPv4 packets.
+    "headers.ipv4.dst_addr::mask != 0 ->     "
+    // Macros are not usable within a single-line string.
+    "  headers.ethernet.ether_type == 0x0800;"
+
+    // Only match on IPv6 addresses of IPv6 packets.
+    "headers.ipv6.dst_addr::mask != 0 ->
+      headers.ethernet.ether_type == IPv6_ETHER_TYPE;"
+
+    // An invalid constraint to ensure error messages are sensible.
+    "::unknown > 10;"
+
+    // More valid stuff.
+    "local_metadata.dscp::mask != 0 -> (
+      headers.ethernet.ether_type == IPv4_ETHER_TYPE ||
+      headers.ethernet.ether_type == IPv6_ETHER_TYPE ||
+      local_metadata.is_ip_packet == 1
+    );
+  ")
+  table invalid_vrf_classifier_table_with_multiline_strings {
+    key = {
+      headers.ethernet.ether_type : ternary;
+      headers.ipv4.dst_addr : ternary;
+      headers.ipv6.dst_addr : ternary;
+      local_metadata.dscp : ternary;
+      local_metadata.is_ip_packet : ternary;
+    }
+    actions = { }
+  }
+
+  @file(__FILE__)
+  @line(__LINE__)
+  @entry_restriction("
+    // Either wildcard or exact match (i.e., 'optional' match).
+    headers.ipv4.dst_addr::mask == 0 || headers.ipv4.dst_addr::mask == -1;
+
+    // Only match on IPv4 addresses of IPv4 packets.
+    headers.ipv4.dst_addr::mask != 0 ->
+      headers.ethernet.ether_type == 0x0800;
+
+    // Only match on IPv6 addresses of IPv6 packets.
+    headers.ipv6.dst_addr::mask != 0 ->
+      headers.ethernet.ether_type == IPv6_ETHER_TYPE;
+
+    // An invalid constraint to ensure error messages are sensible.
+    ::unknown > 10;
+
+    // More valid stuff.
+    local_metadata.dscp::mask != 0 -> (
+      headers.ethernet.ether_type == IPv4_ETHER_TYPE ||
+      headers.ethernet.ether_type == IPv6_ETHER_TYPE ||
+      local_metadata.is_ip_packet == 1
+    );
+  ")
+  table invalid_vrf_classifier_table_without_multiline_strings {
+    key = {
+      headers.ethernet.ether_type : ternary;
+      headers.ipv4.dst_addr : ternary;
+      headers.ipv6.dst_addr : ternary;
+      local_metadata.dscp : ternary;
+      local_metadata.is_ip_packet : ternary;
+    }
+    actions = { }
+  }
+
   apply {
     forgot_quotes.apply();
     forgot_quotes_with_srcloc.apply();
@@ -119,6 +190,8 @@ control invalid_constraints(inout headers_t headers,
     boolean_negation_of_integer.apply();
     optional_does_not_support_ordered_comparison.apply();
     unknown_metadata.apply();
+    invalid_vrf_classifier_table_with_multiline_strings.apply();
+    invalid_vrf_classifier_table_without_multiline_strings.apply();
    }
  }
 

--- a/e2e_tests/valid_constraints.expected.output
+++ b/e2e_tests/valid_constraints.expected.output
@@ -11,7 +11,7 @@ e2e_tests/table_entries/acl_table_1.pb.txt
 All entries must satisfy:
 
 e2e_tests/valid_constraints.p4:22:5-65:
-   |     // Either wildcard or exact match (i.e., " optional " match).
+   |     // Either wildcard or exact match (i.e., 'optional' match).
 22 |     hdr.ipv4.dst_addr::mask == 0 || hdr.ipv4.dst_addr::mask == -1;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -84,10 +84,10 @@ e2e_tests/table_entries/optional_match_table_invalid_1.pb.txt
 === Output ===
 All entries must satisfy:
 
-e2e_tests/valid_constraints.p4:62:5-32:
-   |     // A real constraint: only wildcard match is okay.
-62 |     hdr.ipv4.dst_addr::mask == 0;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+e2e_tests/valid_constraints.p4:100:5-32:
+    |     // A real constraint: only wildcard match is okay.
+100 |     hdr.ipv4.dst_addr::mask == 0;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
 >>>Relevant Entry Info<<<
@@ -107,10 +107,10 @@ e2e_tests/table_entries/optional_match_table_valid_max_priority.pb.txt
 === Output ===
 All entries must satisfy:
 
-e2e_tests/valid_constraints.p4:64:5-27:
-   |     // A constraint on metadata.
-64 |     ::priority < 0x7fffffff;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+e2e_tests/valid_constraints.p4:102:5-27:
+    |     // A constraint on metadata.
+102 |     ::priority < 0x7fffffff;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 But your entry does not.
 >>>Relevant Entry Info<<<


### PR DESCRIPTION
[p4-constraints] Allow C++ compliant multi-line strings.

I.e. strings like:
```
  "This is the start of my string "
  "and this is the end."
```

This will help solve a C++ preprocessor issue we're having where it will randomly insert preprocessor directives into the `@entry_restriction` annotation string when using a single multi-line string.
