### PR TITLE
Replace undefined std::Container<const T> with std::Container<T>

### DIFF
--- a/p4_constraints/backend/type_checker.cc
+++ b/p4_constraints/backend/type_checker.cc
@@ -191,7 +191,7 @@ using CompositeTypeAndField = std::tuple<Type::TypeCase, std::string>;
 
 // (composite type, field name) -> field type.
 const auto* const kFieldTypes =
-    new absl::flat_hash_map<const CompositeTypeAndField, const Type::TypeCase>{
+    new absl::flat_hash_map<CompositeTypeAndField, const Type::TypeCase>{
         {std::make_tuple(Type::kExact, "value"), Type::kFixedUnsigned},
         {std::make_tuple(Type::kTernary, "value"), Type::kFixedUnsigned},
         {std::make_tuple(Type::kTernary, "mask"), Type::kFixedUnsigned},


### PR DESCRIPTION
Replace undefined std::Container<const T> with std::Container<T>

std::vector<const T> (and other container types:
deque/forward_list/list/multiset/queue/set/stack) are undefined and disallowed
by libstdc++. Future libc++ will report errors as well. Migrate to
std::Container<T> to bring code in-line with the C++ standard and the behavior
of other C++ standard libraries. Make similar changes to absl::flat_hash_set.
