### PR TITLE
Prepare code for breaking change in Protobuf C++ API.

### DIFF
--- a/gutils/protocol_buffer_matchers.cc
+++ b/gutils/protocol_buffer_matchers.cc
@@ -28,6 +28,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "google/protobuf/descriptor.h"
@@ -330,8 +331,9 @@ bool ProtoCompare(const internal::ProtoComparison& comp,
 // Describes the types of the expected and the actual protocol buffer.
 std::string DescribeTypes(const google::protobuf::Message& expected,
                           const google::protobuf::Message& actual) {
-  return "whose type should be " + expected.GetDescriptor()->full_name() +
-         " but actually is " + actual.GetDescriptor()->full_name();
+  return absl::StrCat("whose type should be ",
+                      expected.GetDescriptor()->full_name(),
+                      " but actually is ", actual.GetDescriptor()->full_name());
 }
 
 // Prints the protocol buffer pointed to by proto.

--- a/gutils/protocol_buffer_matchers.h
+++ b/gutils/protocol_buffer_matchers.h
@@ -612,11 +612,11 @@ class WhenDeserializedMatcherBase {
   virtual Proto* MakeEmptyProto() const = 0;
 
   // Type name of the expected protobuf.
-  virtual std::string ExpectedTypeName() const = 0;
+  virtual absl::string_view ExpectedTypeName() const = 0;
 
   // Name of the type argument given to WhenDeserializedAs<>(), or
   // "protobuf" for WhenDeserialized().
-  virtual std::string TypeArgName() const = 0;
+  virtual absl::string_view TypeArgName() const = 0;
 
   // Deserializes the std::string as a protobuf of the same type as the expected
   // protobuf.
@@ -711,11 +711,11 @@ class WhenDeserializedMatcher
     return expected_proto_->New();
   }
 
-  virtual std::string ExpectedTypeName() const {
+  virtual absl::string_view ExpectedTypeName() const {
     return expected_proto_->GetDescriptor()->full_name();
   }
 
-  virtual std::string TypeArgName() const { return "protobuf"; }
+  virtual absl::string_view TypeArgName() const { return "protobuf"; }
 
  private:
   // The expected protobuf specified in the inner matcher
@@ -736,11 +736,11 @@ class WhenDeserializedAsMatcher : public WhenDeserializedMatcherBase<Proto> {
 
   virtual Proto* MakeEmptyProto() const { return new Proto; }
 
-  virtual std::string ExpectedTypeName() const {
+  virtual absl::string_view ExpectedTypeName() const {
     return Proto().GetDescriptor()->full_name();
   }
 
-  virtual std::string TypeArgName() const { return ExpectedTypeName(); }
+  virtual absl::string_view TypeArgName() const { return ExpectedTypeName(); }
 };
 
 // Implements the IsInitializedProto matcher, which is used to verify that a


### PR DESCRIPTION
Protobuf 6.30.0 will change the return types of Descriptor::name() and other
methods to absl::string_view. This makes the code work both before and after
such a change.