### PR TITLE
Add SPDX license identifier comment to most source files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,23 @@ send us an email (p4-dev@lists.p4.org).
 
 ## Apache CLA
 
-All developers must sign the [P4.org](http://p4.org) CLA and return it to
-(membership@p4.org) before making contributions. The CLA is available
-[here](https://p4.org/assets/P4_Language_Consortium_Membership_Agreement.pdf).
+Developers must use DCO ([Developer Certificate of
+Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin))
+to sign every commit that they wish to merge into this repository.
+See [this
+announcement](https://lists.p4.org/g/p4-announce/topic/github_contributor_license/107784276)
+for more details.
+
+## SPDX License Identifier
+
+To enable the use of some automated tools for tracking software
+licenses, both in this project and in any future projects that might
+copy source files from it, all source files must have a comment
+containing an SPDX License Identifier.
+
+TODO: Add a link to a central p4lang repository document about this,
+when one is created.  Probably that will be
+https://github.com/p4lang/p4c/blob/main/docs/licenses.md
 
 ## Coding guidelines
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Please note that every file containing source code must include the following
 copyright header:
 
     Copyright 2020 The P4-Constraints Authors
+    SPDX-License-Identifier: Apache-2.0
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -246,5 +247,5 @@ copyright header:
 This can be done automatically using
 [addlicense](https://github.com/google/addlicense) as follows:
 ```sh
-addlicense -c "The P4-Constraints Authors" -l apache ./p4_constraints
+addlicense -c "The P4-Constraints Authors" -s -l apache ./p4_constraints
 ```

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ Please note that every file containing source code must include the following
 copyright header:
 
     Copyright 2020 The P4-Constraints Authors
-    SPDX-License-Identifier: Apache-2.0
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -243,6 +242,8 @@ copyright header:
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+    SPDX-License-Identifier: Apache-2.0
 
 This can be done automatically using
 [addlicense](https://github.com/google/addlicense) as follows:

--- a/gutils/collections.h
+++ b/gutils/collections.h
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/ordered_map.h
+++ b/gutils/ordered_map.h
@@ -1,4 +1,5 @@
 // Copyright 2020 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/overload.h
+++ b/gutils/overload.h
@@ -1,4 +1,5 @@
 // Copyright 2021 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/parse_text_proto.h
+++ b/gutils/parse_text_proto.h
@@ -1,4 +1,5 @@
 // Copyright 2019 The MediaPipe Authors.
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/protocol_buffer_matchers.cc
+++ b/gutils/protocol_buffer_matchers.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright 2018 Google LLC.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gutils/protocol_buffer_matchers.h
+++ b/gutils/protocol_buffer_matchers.h
@@ -2,6 +2,7 @@
 
 /*
  * Copyright 2018 Google LLC.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gutils/ret_check.cc
+++ b/gutils/ret_check.cc
@@ -1,4 +1,5 @@
 // Copyright 2019 The MediaPipe Authors.
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/ret_check.h
+++ b/gutils/ret_check.h
@@ -1,4 +1,5 @@
 // Copyright 2019 The MediaPipe Authors.
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/source_location.h
+++ b/gutils/source_location.h
@@ -1,4 +1,5 @@
 // Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/status_builder.cc
+++ b/gutils/status_builder.cc
@@ -1,4 +1,5 @@
 // Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/status_builder.h
+++ b/gutils/status_builder.h
@@ -1,4 +1,5 @@
 // Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/status_macros.h
+++ b/gutils/status_macros.h
@@ -1,4 +1,5 @@
 // Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/status_matchers.h
+++ b/gutils/status_matchers.h
@@ -1,6 +1,7 @@
 // Copied and adapted from https://github.com/google/iree.
 
 // Copyright 2019 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/testing.cc
+++ b/gutils/testing.cc
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gutils/testing.h
+++ b/gutils/testing.h
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/ast.cc
+++ b/p4_constraints/ast.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/ast.h
+++ b/p4_constraints/ast.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/ast.proto
+++ b/p4_constraints/ast.proto
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/ast_test.cc
+++ b/p4_constraints/ast_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/constraint_info.cc
+++ b/p4_constraints/backend/constraint_info.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/constraint_info.h
+++ b/p4_constraints/backend/constraint_info.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/interpreter.cc
+++ b/p4_constraints/backend/interpreter.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/interpreter.h
+++ b/p4_constraints/backend/interpreter.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/interpreter_golden_test_runner.cc
+++ b/p4_constraints/backend/interpreter_golden_test_runner.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/interpreter_test.cc
+++ b/p4_constraints/backend/interpreter_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/symbolic_interpreter.cc
+++ b/p4_constraints/backend/symbolic_interpreter.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/symbolic_interpreter.h
+++ b/p4_constraints/backend/symbolic_interpreter.h
@@ -7,6 +7,7 @@
 
 /*
  * Copyright 2023 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/type_checker.cc
+++ b/p4_constraints/backend/type_checker.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/type_checker.h
+++ b/p4_constraints/backend/type_checker.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/backend/type_checker_test.cc
+++ b/p4_constraints/backend/type_checker_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/cli/p4check.cc
+++ b/p4_constraints/cli/p4check.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/constraint_source.h
+++ b/p4_constraints/constraint_source.h
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/ast_constructors.cc
+++ b/p4_constraints/frontend/ast_constructors.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/ast_constructors.h
+++ b/p4_constraints/frontend/ast_constructors.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/constraint_kind.h
+++ b/p4_constraints/frontend/constraint_kind.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/lexer.cc
+++ b/p4_constraints/frontend/lexer.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/lexer.h
+++ b/p4_constraints/frontend/lexer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/lexer_test.cc
+++ b/p4_constraints/frontend/lexer_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/parser.cc
+++ b/p4_constraints/frontend/parser.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/parser.h
+++ b/p4_constraints/frontend/parser.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/parser_test.cc
+++ b/p4_constraints/frontend/parser_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/token.cc
+++ b/p4_constraints/frontend/token.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/token.h
+++ b/p4_constraints/frontend/token.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/p4_constraints/frontend/token_test.cc
+++ b/p4_constraints/frontend/token_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/quote.cc
+++ b/p4_constraints/quote.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 The P4-Constraints Authors
+// SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/p4_constraints/quote.h
+++ b/p4_constraints/quote.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 The P4-Constraints Authors
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
I will create an issue containing the list of source files that I am _not_ adding SPDX-License-Identifier lines to -- the ones where there is no copyright notice in comments that I could find, so it is a bit more time-consuming to track down who the author of the file is and what the copyright year is, but this is a good start on the files where these were already present.