### PR TITLE
Simplify format.sh by Invoking prebuilt buildifier binary via Bazel.

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -50,9 +50,34 @@ load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
-# -- Load Rules Foreign CC -----------------------------------------------------
+# -- Load Rules Foreign CC (for building Z3) -----------------------------------
 # Used for Z3.
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
+
+# -- Load Buildifier (for formatting) ------------------------------------------
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "5dbf72e4f93917edfb91f53958d6289736adb845b2b89dbfb9bfc199a492030c",
+    strip_prefix = "buildifier-prebuilt-8.0.1",
+    urls = [
+        "http://github.com/keith/buildifier-prebuilt/archive/8.0.1.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()

--- a/format.sh
+++ b/format.sh
@@ -15,31 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#
 # Formats source files according to Google's style guide. Requires clang-format.
-# 
-# If you're on macOS with Apple silicon (M1, M2, M3, ...), call using
-# ```
-# PLATFORM=darown-arm64 ./format.sh
-# ```
-# 
-# If you're on macOS with Intel silicon, call using
-# ```
-# PLATFORM=darown-amd64 ./format.sh
-# ```
-# and similarly for other platforms.
-
-# Possible values: {linux, darwin}_{amd64, arm64}.
-which dpkg
-exit_status=$?
-if [ ${exit_status} -eq 0 ]
-then
-    ARCH=`dpkg --print-architecture`
-    PLATFORM=${PLATFORM:-linux-${ARCH}}
-else
-    # Guess amd64
-    PLATFORM=${PLATFORM:-linux-amd64}
-fi
 
 # Only files with these extensions will be formatted by clang-format.
 CLANG_FORMAT_EXTENSIONS="cc|h|proto"
@@ -49,12 +25,4 @@ find . -not -path "./third_party/**" \
   | egrep "\.(${CLANG_FORMAT_EXTENSIONS})\$" \
   | xargs clang-format --verbose -style=google -i
 
-# Run buildifier (Bazel file formatter).
-if [ ! -e buildifier ]
-then
-    BUILDIFIER="buildifier-$PLATFORM"
-    wget "https://github.com/bazelbuild/buildtools/releases/download/v8.0.3/$BUILDIFIER"
-    mv $BUILDIFIER buildifier
-    chmod +x buildifier
-fi
-./buildifier --lint=fix -r .
+bazel run -- @buildifier_prebuilt//:buildifier --lint=fix -r .


### PR DESCRIPTION
Fixes #162.