### PR TITLE
Make it explicit that arithmetic negation of int field/attribute access is allowed.

### DIFF
--- a/docs/language-specification.md
+++ b/docs/language-specification.md
@@ -183,6 +183,16 @@ can be expressed more succinctly without parentheses as
 
 Like P4, the language also provides the Boolean constants `true` and `false`.
 
+### Other unary operations
+
+Currently, besides field/attribute access and boolean negation (`!`) introduced
+above, the only unary operation allowed is arithmetic negation (`-`).
+
+Arithmetic negation can be applied on any `int` type expressions (including
+numeric constant, `int` key, and `int` field/attribute access) and the result is
+also `int` type. The semantics of arithmetic negation is to get the negative
+value of the signed integer operand.
+
 ### Network address syntax
 
 A table entry may want to restrict certain values to valid network addresses. For example, the following constraint sets restrictions on IPv4, IPv6 and MAC addresses.

--- a/p4_constraints/backend/type_checker_test.cc
+++ b/p4_constraints/backend/type_checker_test.cc
@@ -290,6 +290,24 @@ TEST_F(InferAndCheckTypesTest, ArithmeticNegationOfIntTypeChecks) {
       R"pb(arithmetic_negation { key: "int" })pb");
   ASSERT_THAT(InferAndCheckTypes(&expr, kTableInfo), IsOk());
   EXPECT_TRUE(expr.type().has_arbitrary_int());
+
+  // Arithmetic negation of int field access.
+  expr = ParseTextProtoOrDie<Expression>(R"pb(arithmetic_negation {
+                                                field_access {
+                                                  field: "prefix_length",
+                                                  expr { key: "lpm32" }
+                                                }
+                                              })pb");
+  ASSERT_THAT(InferAndCheckTypes(&expr, kTableInfo), IsOk());
+  EXPECT_TRUE(expr.type().has_arbitrary_int());
+
+  // Arithmetic negation of int attribute access.
+  expr = ParseTextProtoOrDie<Expression>(
+      R"pb(arithmetic_negation {
+             attribute_access { attribute_name: "priority" }
+           })pb");
+  ASSERT_THAT(InferAndCheckTypes(&expr, kTableInfo), IsOk());
+  EXPECT_TRUE(expr.type().has_arbitrary_int());
 }
 
 TEST_F(InferAndCheckTypesTest, ArithmeticNegationOfNonIntDoesNotTypeChecks) {


### PR DESCRIPTION
The current language spec doc is not very clear about this. Also added tests to cover these cases.

PiperOrigin-RevId: 747625360