### PR TITLE
Fix performance bug (unnecssary copying) in p4-constraints parsing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ copy source files from it, all source files must have a comment
 containing an SPDX License Identifier.
 
 TODO: Add a link to a central p4lang repository document about this,
-when one is created.  Probably that will be
+when one is created. Probably that will be
 https://github.com/p4lang/p4c/blob/main/docs/licenses.md
 
 ## Coding guidelines

--- a/p4_constraints/BUILD.bazel
+++ b/p4_constraints/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-
-# GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+# GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:proto_library.bzl", "proto_library")
+
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(


### PR DESCRIPTION
Fix performance bug (unnecssary copying) in p4-constraints parsing.

Gives roughly a 2x speedup.

I noticed this in matthewtlam@'s flame graph: https://b.corp.google.com/issues/422779298#comment2

Before: http://pprof/?id=732593fb60320a2ba8dee230e17a4fb2&tab=flame
After: http://pprof/?id=d567ff51591a8e03269c92e4f03ef043&tab=flame
