### PR TITLE
Stop re-exporting cc_proto_library from rules_cc

### DIFF
--- a/p4_constraints/BUILD.bazel
+++ b/p4_constraints/BUILD.bazel
@@ -1,12 +1,17 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+# GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:cc_proto_library.bzl", "cc_proto_library")
 # GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:proto_library.bzl", "proto_library")
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_applicable_licenses = ["//third_party/p4lang_p4_constraints:license"],
+    default_visibility = [
+        "//third_party/p4lang_p4_constraints:__subpackages__",
+        "//third_party/pins_infra/p4_fuzzer:__subpackages__",
+        "@com_github_p4lang_p4c///backends/p4tools:__subpackages__",
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/p4_constraints/backend/BUILD.bazel
+++ b/p4_constraints/backend/BUILD.bazel
@@ -3,7 +3,17 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//e2e_tests:p4check.bzl", "cmd_diff_test")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_applicable_licenses = ["//third_party/p4lang_p4_constraints:license"],
+    default_visibility = [
+        "//platforms/networking/apes/z3/lib/lego_herc:__subpackages__",
+        "//platforms/networking/orion/p4/ofpd/testing:__subpackages__",
+        "//third_party/p4lang_p4_constraints:__subpackages__",
+        "//third_party/pins_infra/p4_fuzzer:__subpackages__",
+        "//third_party/pins_infra/p4rt_app:__subpackages__",
+        "//third_party/pins_infra/sai_p4/instantiations/google:__subpackages__",
+        "//third_party/pins_infra/tests/forwarding:__subpackages__",
+        "@com_github_p4lang_p4c///backends/p4tools:__subpackages__",
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 

--- a/p4_constraints/frontend/BUILD.bazel
+++ b/p4_constraints/frontend/BUILD.bazel
@@ -2,6 +2,12 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
+    default_applicable_licenses = ["//third_party/p4lang_p4_constraints:license"],
+    default_visibility = [
+        "//third_party/p4lang_p4_constraints:__subpackages__",
+        "//third_party/pins_infra/p4_fuzzer:__subpackages__",
+        "@com_github_p4lang_p4c///backends/p4tools:__subpackages__",
+    ],
     licenses = ["notice"],  # Apache 2.0
 )
 
@@ -9,7 +15,6 @@ cc_library(
     name = "parser",
     srcs = ["parser.cc"],
     hdrs = ["parser.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":ast_constructors",
         ":constraint_kind",
@@ -49,7 +54,6 @@ cc_library(
     name = "lexer",
     srcs = ["lexer.cc"],
     hdrs = ["lexer.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":token",
         "//p4_constraints:ast",
@@ -124,5 +128,4 @@ cc_library(
 cc_library(
     name = "constraint_kind",
     hdrs = ["constraint_kind.h"],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Stop re-exporting cc_proto_library from rules_cc

So that rules_cc can be added to components.

#codehealth(pefoley)

Tested:
    TAP --sample ran all affected tests and none failed
    http://test/OCL:786688910:BASE:786644183:1753365647656:a787e6dd
