### PR TITLE
[P4 Constraints] Stop re-exporting cc_proto_library from rules_cc

### DIFF
--- a/p4_constraints/BUILD.bazel
+++ b/p4_constraints/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+# GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:cc_proto_library.bzl", "cc_proto_library")
 # GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:proto_library.bzl", "proto_library")
 
 load("@rules_proto//proto:defs.bzl", "proto_library")


### PR DESCRIPTION
[P4 Constraints] Stop re-exporting cc_proto_library from rules_cc
