### PR TITLE
[P4-Constraints] Added ConstraintSolver hook to export constraints to…

### DIFF
--- a/p4_constraints/backend/symbolic_interpreter.cc
+++ b/p4_constraints/backend/symbolic_interpreter.cc
@@ -47,6 +47,7 @@
 #include "p4_constraints/frontend/constraint_kind.h"
 #include "p4_constraints/frontend/parser.h"
 #include "z3++.h"
+#include "z3_api.h"
 
 namespace p4_constraints {
 namespace {
@@ -831,6 +832,162 @@ absl::StatusOr<z3::expr> GetMask(const SymbolicKey& symbolic_key) {
 
 absl::StatusOr<z3::expr> GetPrefixLength(const SymbolicKey& symbolic_key) {
   return GetFieldAccess(symbolic_key, "prefix_length");
+}
+
+// Substitute variable names in `expr`, replacing variables in `src_env` with
+// ones in `dst_env`. Note that `dst_env` is a subset of `src_env` and may not
+// share the same z3 context.
+absl::StatusOr<z3::expr> TranslateBySymbolicEnvironment(
+    z3::expr expr, const SymbolicEnvironment& src_env,
+    const SymbolicEnvironment& dst_env) {
+  for (const auto& entry : dst_env.symbolic_key_by_name) {
+    const auto& key_name = entry.first;
+    const auto& dst_key = entry.second;
+    auto src_it = src_env.symbolic_key_by_name.find(key_name);
+    if (src_it == src_env.symbolic_key_by_name.end()) {
+      return gutils::InvalidArgumentErrorBuilder(GUTILS_LOC)
+             << "Cannot rename nonexistent key '" << key_name
+             << "' specified in destination but not in source.";
+    }
+    const SymbolicKey& src_key = src_it->second;
+
+    // Replace `src_env` variables appearing in `expr` with the
+    // corresponding `dst_env` variables.
+    z3::expr_vector from(expr.ctx());
+    z3::expr_vector to(expr.ctx());
+    ASSIGN_OR_RETURN(
+        expr,
+        std::visit(
+            gutils::Overload{
+                [&](const SymbolicExact& src_exact)
+                    -> absl::StatusOr<z3::expr> {
+                  const SymbolicExact& dst_exact =
+                      std::get<SymbolicExact>(dst_key);
+                  z3::expr translated_dst_value = z3::to_expr(
+                      expr.ctx(), Z3_translate(dst_exact.value.ctx(),
+                                               dst_exact.value, expr.ctx()));
+                  if (!eq(src_exact.value.get_sort(),
+                          translated_dst_value.get_sort())) {
+                    return gutils::InternalErrorBuilder(GUTILS_LOC)
+                           << "Mismatched Z3 sorts during symbolic translation "
+                              "for "
+                              "key '"
+                           << key_name << "': src sort is "
+                           << src_exact.value.get_sort() << ", dst sort is "
+                           << translated_dst_value.get_sort();
+                  }
+                  from.push_back(src_exact.value);
+                  to.push_back(translated_dst_value);
+                  return expr.substitute(from, to);
+                },
+                [&](const SymbolicTernary& src_ternary)
+                    -> absl::StatusOr<z3::expr> {
+                  const SymbolicTernary& dst_ternary =
+                      std::get<SymbolicTernary>(dst_key);
+                  // Translate dst_ternary values to the context of expr.
+                  z3::expr translated_dst_value = z3::to_expr(
+                      expr.ctx(), Z3_translate(dst_ternary.value.ctx(),
+                                               dst_ternary.value, expr.ctx()));
+                  z3::expr translated_dst_mask = z3::to_expr(
+                      expr.ctx(), Z3_translate(dst_ternary.mask.ctx(),
+                                               dst_ternary.mask, expr.ctx()));
+                  if (!eq(src_ternary.value.get_sort(),
+                          translated_dst_value.get_sort())) {
+                    return gutils::InternalErrorBuilder(GUTILS_LOC)
+                           << "Mismatched Z3 sorts during symbolic translation "
+                              "for "
+                              "key '"
+                           << key_name << "': src sort is "
+                           << src_ternary.value.get_sort() << ", dst sort is "
+                           << translated_dst_value.get_sort();
+                  }
+                  if (!eq(src_ternary.mask.get_sort(),
+                          translated_dst_mask.get_sort())) {
+                    return gutils::InternalErrorBuilder(GUTILS_LOC)
+                           << "Mismatched Z3 sorts during symbolic translation "
+                              "for "
+                              "mask of key '"
+                           << key_name << "': src sort is "
+                           << src_ternary.mask.get_sort() << ", dst sort is "
+                           << translated_dst_mask.get_sort();
+                  }
+                  from.push_back(src_ternary.value);
+                  to.push_back(translated_dst_value);
+                  from.push_back(src_ternary.mask);
+                  to.push_back(translated_dst_mask);
+                  return expr.substitute(from, to);
+                },
+                [&](const SymbolicLpm& src_lpm) -> absl::StatusOr<z3::expr> {
+                  const SymbolicLpm& dst_lpm = std::get<SymbolicLpm>(dst_key);
+                  z3::expr translated_dst_value = z3::to_expr(
+                      expr.ctx(), Z3_translate(dst_lpm.value.ctx(),
+                                               dst_lpm.value, expr.ctx()));
+                  z3::expr translated_dst_prefix_length = z3::to_expr(
+                      expr.ctx(),
+                      Z3_translate(dst_lpm.prefix_length.ctx(),
+                                   dst_lpm.prefix_length, expr.ctx()));
+                  if (!eq(src_lpm.value.get_sort(),
+                          translated_dst_value.get_sort())) {
+                    return gutils::InternalErrorBuilder(GUTILS_LOC)
+                           << "Mismatched Z3 sorts during symbolic translation "
+                              "for "
+                              "key '"
+                           << key_name << "': src sort is "
+                           << src_lpm.value.get_sort() << ", dst sort is "
+                           << translated_dst_value.get_sort();
+                  }
+                  if (!eq(src_lpm.prefix_length.get_sort(),
+                          translated_dst_prefix_length.get_sort())) {
+                    return gutils::InternalErrorBuilder(GUTILS_LOC)
+                           << "Mismatched Z3 sorts during symbolic translation "
+                              "for "
+                              "prefix_length of key '"
+                           << key_name << "': src sort is "
+                           << src_lpm.prefix_length.get_sort()
+                           << ", dst sort is "
+                           << translated_dst_prefix_length.get_sort();
+                  }
+                  from.push_back(src_lpm.value);
+                  to.push_back(translated_dst_value);
+                  from.push_back(src_lpm.prefix_length);
+                  to.push_back(translated_dst_prefix_length);
+                  return expr.substitute(from, to);
+                },
+            },
+            src_key));
+  }
+
+  // Substitute attribute names.
+  for (const auto& [attribute_name, dst_attribute] :
+       dst_env.symbolic_attribute_by_name) {
+    auto src_it = src_env.symbolic_attribute_by_name.find(attribute_name);
+    if (src_it == src_env.symbolic_attribute_by_name.end()) continue;
+    const SymbolicAttribute& src_attribute = src_it->second;
+    z3::expr translated_dst_value =
+        z3::to_expr(expr.ctx(), Z3_translate(dst_attribute.value.ctx(),
+                                             dst_attribute.value, expr.ctx()));
+    z3::expr_vector from(expr.ctx());
+    z3::expr_vector to(expr.ctx());
+    from.push_back(src_attribute.value);
+    to.push_back(translated_dst_value);
+    expr = expr.substitute(from, to);
+  }
+  return expr;
+}
+
+absl::Status ConstraintSolver::ExportConstraintsToTargetSolver(
+    z3::solver& solver, const SymbolicEnvironment& environment) {
+  z3::expr_vector constraints(solver.ctx());
+  for (z3::expr assertion : solver_->assertions()) {
+    ASSIGN_OR_RETURN(
+        z3::expr translated_assertion,
+        TranslateBySymbolicEnvironment(assertion, environment_, environment));
+    constraints.push_back(z3::to_expr(
+        solver.ctx(),
+        Z3_translate(*context_, translated_assertion, solver.ctx())));
+  }
+  solver.add(constraints);
+  return absl::OkStatus();
 }
 
 }  // namespace p4_constraints

--- a/p4_constraints/backend/symbolic_interpreter.h
+++ b/p4_constraints/backend/symbolic_interpreter.h
@@ -31,6 +31,7 @@
 #include <variant>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -121,12 +122,17 @@ class ConstraintSolver {
   // TODO(b/242201770): Extract actions once action constraints are supported.
   absl::StatusOr<p4::v1::TableEntry> ConcretizeEntry();
 
+  // Adds the ConstraintSolver's constraints to the target solver.
+  // Renames variables according to the passed SymbolicEnvironment as needed.
+  absl::Status ExportConstraintsToTargetSolver(
+      z3::solver& solver, const SymbolicEnvironment& environment);
+
  private:
   explicit ConstraintSolver()
       : context_(std::make_unique<z3::context>()),
         solver_(std::make_unique<z3::solver>(*context_)) {}
 
-  // Z3 context and solver. Solver requires a reference to `context` for
+  // Z3 context and solver. 'solver' requires a reference to `context` for
   // construction so it is privately stored to avoid dangling reference.
   std::unique_ptr<z3::context> context_;
   std::unique_ptr<z3::solver> solver_;

--- a/p4_constraints/backend/symbolic_interpreter_test.cc
+++ b/p4_constraints/backend/symbolic_interpreter_test.cc
@@ -1213,5 +1213,221 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<FullySpecifiedAdditionalConstraintTestCase>&
            info) { return SnakeCaseToCamelCase(info.param.test_name); });
 
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsCorrectlyRenamesExactMatchKeys) {
+  TableInfo table_info =
+      GetTableInfoWithConstraint("exact32 == 42 && exact11 == 1");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver src_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dst_context;
+  z3::solver dst_solver(dst_context);
+  // Change one variable name to make sure the renaming works.
+  z3::expr renamed_exact32 = dst_context.bv_const("exact32_renamed", 32);
+  SymbolicEnvironment dst_environment;
+  dst_environment.symbolic_key_by_name.insert(
+      {"exact32", SymbolicExact{.value = renamed_exact32}});
+  ASSERT_OK(
+      src_solver.ExportConstraintsToTargetSolver(dst_solver, dst_environment));
+
+  // Check that the constraint "exact32_renamed == 42" has been added correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_exact32 != 42);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+
+  // Check that other constraints have been added correctly.
+  // The constraint "exact11 == 1" should have been added to dest_solver.
+  dst_solver.push();
+  z3::expr exact11_in_dest = dst_context.bv_const("exact11", 11);
+  dst_solver.add(exact11_in_dest == 2);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsCorrectlyRenamesOptionalMatchKeys) {
+  TableInfo table_info =
+      GetTableInfoWithConstraint("optional32 == 42 && optional32::mask == -1");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dst_context;
+  z3::solver dst_solver(dst_context);
+  // Change optional32 variable names to make sure the renaming works.
+  z3::expr renamed_optional32 = dst_context.bv_const("optional32_renamed", 32);
+  z3::expr renamed_optional32_mask =
+      dst_context.bv_const("optional32_renamed::mask", 32);
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_key_by_name.insert(
+      {"optional32", SymbolicTernary{.value = renamed_optional32,
+                                     .mask = renamed_optional32_mask}});
+  ASSERT_OK(source_solver.ExportConstraintsToTargetSolver(dst_solver,
+                                                          dest_environment));
+
+  // Check that the constraint "optional32_renamed == 42" has been added
+  // correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_optional32 != 42);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+
+  // Check that the constraint "optional32_renamed.mask > 0" has been added
+  // correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_optional32_mask == 0);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsCorrectlyRenamesTernaryMatchKeys) {
+  TableInfo table_info =
+      GetTableInfoWithConstraint("ternary32 == 42 && ternary32::mask != 20");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dst_context;
+  z3::solver dst_solver(dst_context);
+  // Change optional32 variable names to make sure the renaming works.
+  z3::expr renamed_ternary32 = dst_context.bv_const("ternary32_renamed", 32);
+  z3::expr renamed_ternary32_mask =
+      dst_context.bv_const("ternary32_renamed::mask", 32);
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_key_by_name.insert(
+      {"ternary32", SymbolicTernary{.value = renamed_ternary32,
+                                    .mask = renamed_ternary32_mask}});
+  ASSERT_OK(source_solver.ExportConstraintsToTargetSolver(dst_solver,
+                                                          dest_environment));
+
+  // Check that the constraint "ternary32_renamed == 42" has been added
+  // correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_ternary32 != 42);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+
+  // Check that the constraint "ternary32_renamed.mask != 20" has been added
+  // correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_ternary32_mask == 20);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsCorrectlyRenamesLpmMatchKeys) {
+  TableInfo table_info =
+      GetTableInfoWithConstraint("lpm32 == 42 && lpm32::prefix_length > 20");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dst_context;
+  z3::solver dst_solver(dst_context);
+  // Change optional32 variable names to make sure the renaming works.
+  z3::expr renamed_lpm32 = dst_context.bv_const("lpm32_renamed", 32);
+  z3::expr renamed_lpm32_prefix_length =
+      dst_context.int_const("lpm32_renamed::prefix_length");
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_key_by_name.insert(
+      {"lpm32", SymbolicLpm{.value = renamed_lpm32,
+                            .prefix_length = renamed_lpm32_prefix_length}});
+  ASSERT_OK(source_solver.ExportConstraintsToTargetSolver(dst_solver,
+                                                          dest_environment));
+
+  // Check that the constraint "lpm32_renamed == 42" has been added correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_lpm32 != 42);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+
+  // Check that the constraint "lpm32_renamed.prefix_length > 20" has been added
+  // correctly.
+  EXPECT_EQ(dst_solver.check(), z3::sat);
+  dst_solver.push();
+  dst_solver.add(renamed_lpm32_prefix_length == 0);
+  EXPECT_EQ(dst_solver.check(), z3::unsat);
+  dst_solver.pop();
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsCorrectlyRenamesAttributes) {
+  TableInfo table_info = GetTableInfoWithConstraint("::priority == 42");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dest_context;
+  z3::solver dest_solver(dest_context);
+
+  // Change one attribute name to make sure the renaming works.
+  z3::expr renamed_priority = dest_context.int_const("priority_renamed");
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_attribute_by_name.insert(
+      {kSymbolicPriorityAttributeName,
+       SymbolicAttribute{.value = renamed_priority}});
+
+  ASSERT_OK(source_solver.ExportConstraintsToTargetSolver(dest_solver,
+                                                          dest_environment));
+
+  // Check that the constraint "priority_renamed == 42" has been added
+  // correctly.
+  EXPECT_EQ(dest_solver.check(), z3::sat);
+  dest_solver.push();
+  dest_solver.add(renamed_priority != 42);
+  EXPECT_EQ(dest_solver.check(), z3::unsat);
+  dest_solver.pop();
+
+  // Check that other constraints have been added correctly.
+  // The constraint "priority > 0" should have been added to dest_solver.
+  dest_solver.push();
+  dest_solver.add(renamed_priority <= 0);
+  EXPECT_EQ(dest_solver.check(), z3::unsat);
+  dest_solver.pop();
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsFailsForDestinationEnvironmentsWithNonexistentKeys) {
+  TableInfo table_info = GetTableInfoWithConstraint("exact32 == 42");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dest_context;
+  z3::solver dest_solver(dest_context);
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_key_by_name.insert(
+      {"nonexistent_key", SymbolicExact{.value = dest_context.bv_const(
+                                            "nonexistent_key.value", 32)}});
+
+  EXPECT_THAT(source_solver.ExportConstraintsToTargetSolver(dest_solver,
+                                                            dest_environment),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       testing::HasSubstr("Cannot rename nonexistent key")));
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsFailsForEnvironmentsWithMismatchedSorts) {
+  TableInfo table_info = GetTableInfoWithConstraint("exact32 == 42");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(table_info));
+
+  z3::context dest_context;
+  z3::solver dest_solver(dest_context);
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_key_by_name.insert(
+      {"nonexistent_key", SymbolicExact{.value = dest_context.bv_const(
+                                            "nonexistent_key.value", 300)}});
+
+  EXPECT_THAT(source_solver.ExportConstraintsToTargetSolver(dest_solver,
+                                                            dest_environment),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       testing::HasSubstr("Cannot rename nonexistent key")));
+}
+
 }  // namespace
 }  // namespace p4_constraints


### PR DESCRIPTION
Adds ConstraintSolver::ExportConstraintsToTargetSolver that adds P4-Constraints constraints to a z3 solver, renaming variables according to a given SymbolicEnvironment if necessary.

 


P.S. To unblock internal Google code relying on these changes, I've rolled back some problematic commits in this PR. Let's commit this to a branch (i.e., not master) if we can. I don't think I can make a new branch on my end.


