### PR TITLE
PUBLIC: Implement support for action constraints in ConstraintSolver.

### DIFF
--- a/e2e_tests/BUILD.bazel
+++ b/e2e_tests/BUILD.bazel
@@ -1,8 +1,6 @@
 load(":p4check.bzl", "diff_test", "run_p4check")
 
-package(
-    licenses = ["notice"],  # Apache 2.0
-)
+licenses(["notice"])
 
 diff_test(
     name = "invalid_constraints_test",

--- a/p4_constraints/BUILD.bazel
+++ b/p4_constraints/BUILD.bazel
@@ -1,14 +1,12 @@
 load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-# GOOGLE ONLY (DO NOT REMOVE): load("//third_party/protobuf/bazel:proto_library.bzl", "proto_library")
-
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
-package(
-    default_visibility = ["//visibility:public"],
-    licenses = ["notice"],  # Apache 2.0
-)
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 cc_library(
     name = "big_int",

--- a/p4_constraints/backend/BUILD.bazel
+++ b/p4_constraints/backend/BUILD.bazel
@@ -2,10 +2,9 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//e2e_tests:p4check.bzl", "cmd_diff_test")
 
-package(
-    default_visibility = ["//visibility:public"],
-    licenses = ["notice"],  # Apache 2.0
-)
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 cc_library(
     name = "interpreter",

--- a/p4_constraints/backend/constraint_info.cc
+++ b/p4_constraints/backend/constraint_info.cc
@@ -79,7 +79,7 @@ void SetConstraintLocationName(ConstraintKind constraint_kind,
       << "ConstraintKind is neither TableConstraint nor ActionConstraint";
 }
 
-absl::StatusOr<absl::optional<ConstraintSource>> ExtractConstraint(
+absl::StatusOr<std::optional<ConstraintSource>> ExtractConstraint(
     ConstraintKind constraint_kind, const Preamble& preamble) {
   // We expect .p4 files to have the following format for tables:
   // ```p4
@@ -247,10 +247,10 @@ absl::StatusOr<TableInfo> ParseTableInfo(const Table& table) {
   }
 
   ASSIGN_OR_RETURN(
-      absl::optional<ConstraintSource> constraint_source,
+      std::optional<ConstraintSource> constraint_source,
       ExtractConstraint(ConstraintKind::kTableConstraint, table.preamble()));
 
-  absl::optional<ast::Expression> constraint = absl::nullopt;
+  std::optional<ast::Expression> constraint = absl::nullopt;
   if (constraint_source.has_value()) {
     ASSIGN_OR_RETURN(
         constraint,
@@ -297,9 +297,9 @@ absl::StatusOr<ActionInfo> ParseActionInfo(const Action& action) {
     }
   }
   ASSIGN_OR_RETURN(
-      absl::optional<ConstraintSource> constraint_source,
+      std::optional<ConstraintSource> constraint_source,
       ExtractConstraint(ConstraintKind::kActionConstraint, action.preamble()));
-  absl::optional<ast::Expression> constraint;
+  std::optional<ast::Expression> constraint;
   if (constraint_source.has_value()) {
     ASSIGN_OR_RETURN(
         constraint,

--- a/p4_constraints/backend/symbolic_interpreter.cc
+++ b/p4_constraints/backend/symbolic_interpreter.cc
@@ -361,8 +361,11 @@ absl::StatusOr<SymbolicEvalResult> EvalSymbolically(
     }
 
     case ast::Expression::kActionParameter: {
-      return absl::UnimplementedError(
-          "TODO: b/293656077 - Support action constraints");
+      ASSIGN_OR_RETURN(
+          const z3::expr* param,
+          gutil::FindPtrOrStatus(environment.symbolic_parameter_by_name,
+                                 expr.action_parameter()));
+      return *param;
     }
 
     case ast::Expression::kFieldAccess: {
@@ -680,19 +683,23 @@ absl::StatusOr<z3::expr> EvaluateConstraintSymbolically(
 
 }  // namespace internal_interpreter
 
-absl::StatusOr<p4::v1::TableEntry> ConstraintSolver::ConcretizeEntry() {
+absl::StatusOr<p4::v1::TableEntry> ConstraintSolver::ConcretizeEntryKey() {
+  if (!table_info_.has_value()) {
+    return gutil::FailedPreconditionErrorBuilder()
+           << "ConcretizeEntryKey is only allowed when TableInfo is provided.";
+  }
   if (solver_->check() != z3::sat) {
     return gutil::InternalErrorBuilder() << "Constraints are not satisfiable.";
   }
 
   z3::model model = solver_->get_model();
   p4::v1::TableEntry table_entry;
-  table_entry.set_table_id(table_info_.id);
+  table_entry.set_table_id(table_info_->id);
 
   // Construct match fields by evaluating their respective entries in the model.
   // Ordered for reproducibility.
   for (const auto& [key_name, key_info] :
-       gutil::AsOrderedView(table_info_.keys_by_name)) {
+       gutil::AsOrderedView(table_info_->keys_by_name)) {
     ASSIGN_OR_RETURN(bool key_should_be_skipped, skip_key_named_(key_name));
     if (key_should_be_skipped) continue;
 
@@ -727,7 +734,43 @@ absl::StatusOr<p4::v1::TableEntry> ConstraintSolver::ConcretizeEntry() {
   return table_entry;
 }
 
-absl::StatusOr<bool> ConstraintSolver::AddConstraint(
+absl::StatusOr<p4::v1::Action> ConstraintSolver::ConcretizeAction() {
+  if (!action_info_.has_value()) {
+    return gutil::FailedPreconditionErrorBuilder()
+           << "ConcretizeAction is only allowed when ActionInfo is provided.";
+  }
+  if (solver_->check() != z3::sat) {
+    return gutil::InternalErrorBuilder() << "Constraints are not satisfiable.";
+  }
+
+  z3::model model = solver_->get_model();
+  p4::v1::Action action;
+  action.set_action_id(action_info_->id);
+
+  // Construct action parameters by evaluating their respective entries in the
+  // model. Ordered for reproducibility.
+  for (const auto& [param_name, param_info] :
+       gutil::AsOrderedView(action_info_->params_by_name)) {
+    ASSIGN_OR_RETURN(const z3::expr* param_expr,
+                     gutil::FindPtrOrStatus(
+                         environment_.symbolic_parameter_by_name, param_name));
+
+    p4::v1::Action::Param* param = action.add_params();
+    param->set_param_id(param_info.id);
+
+    ASSIGN_OR_RETURN(int bitwidth, ast::TypeBitwidthOrStatus(param_info.type));
+
+    // Evaluate the parameter value in the model.
+    std::string z3_value =
+        model.eval(*param_expr, /*model_completion=*/true).to_string();
+    ASSIGN_OR_RETURN(*param->mutable_value(),
+                     Z3BitvectorValueToP4RuntimeBytestring(z3_value, bitwidth));
+  }
+
+  return action;
+}
+
+absl::StatusOr<bool> ConstraintSolver::AddConstraintInternal(
     const ast::Expression& constraint,
     const ConstraintSource& constraint_source) {
   if (solver_->check() != z3::sat) {
@@ -748,10 +791,14 @@ absl::StatusOr<bool> ConstraintSolver::AddConstraint(
   return true;
 };
 
-absl::StatusOr<bool> ConstraintSolver::AddConstraint(
+absl::StatusOr<bool> ConstraintSolver::AddTableConstraint(
     absl::string_view constraint_string) {
+  if (!table_info_.has_value()) {
+    return gutil::FailedPreconditionErrorBuilder()
+           << "AddTableConstraint is only allowed when TableInfo is provided.";
+  }
   ast::SourceLocation source_location;
-  source_location.set_table_name(table_info_.name);
+  source_location.set_table_name(table_info_->name);
 
   ConstraintSource constraint_source{
       .constraint_string = std::string(constraint_string),
@@ -762,9 +809,10 @@ absl::StatusOr<bool> ConstraintSolver::AddConstraint(
       ast::Expression constraint_ast,
       ParseConstraint(ConstraintKind::kTableConstraint, constraint_source));
 
-  RETURN_IF_ERROR(InferAndCheckTypes(&constraint_ast, table_info_));
+  RETURN_IF_ERROR(InferAndCheckTypes(&constraint_ast, *table_info_));
 
-  return ConstraintSolver::AddConstraint(constraint_ast, constraint_source);
+  return ConstraintSolver::AddConstraintInternal(constraint_ast,
+                                                 constraint_source);
 }
 
 absl::StatusOr<ConstraintSolver> ConstraintSolver::Create(
@@ -772,7 +820,7 @@ absl::StatusOr<ConstraintSolver> ConstraintSolver::Create(
     std::function<absl::StatusOr<bool>(absl::string_view key_name)>
         skip_key_named) {
   ConstraintSolver constraint_solver = ConstraintSolver();
-  constraint_solver.table_info_ = std::move(table);
+  constraint_solver.table_info_ = table;
   constraint_solver.skip_key_named_ = std::move(skip_key_named);
 
   // Add keys to solver and map and determine whether the table needs a
@@ -780,7 +828,7 @@ absl::StatusOr<ConstraintSolver> ConstraintSolver::Create(
   bool requires_priority = false;
   // Ordered for reproducibility.
   for (const auto& [key_name, key_info] :
-       gutil::AsOrderedView(constraint_solver.table_info_.keys_by_name)) {
+       gutil::AsOrderedView(constraint_solver.table_info_->keys_by_name)) {
     if (key_info.type.has_ternary() || key_info.type.has_optional_match()) {
       // In P4Runtime, all tables with ternaries or optionals require priorities
       // for their entries.
@@ -806,14 +854,51 @@ absl::StatusOr<ConstraintSolver> ConstraintSolver::Create(
 
   if (table.constraint.has_value()) {
     ASSIGN_OR_RETURN(bool modeled_constraint_added,
-                     constraint_solver.AddConstraint(*table.constraint,
-                                                     table.constraint_source));
+                     constraint_solver.AddConstraintInternal(
+                         *table.constraint, table.constraint_source));
     if (!modeled_constraint_added) {
       return gutil::InvalidArgumentErrorBuilder()
              << "TableInfo provided an unsatisfiable constraint. "
                 "ConstraintSolver must contain a satisfiable constraint at all "
                 "times so creation failed.\n Unsatisfiable Constraint: "
              << table.constraint_source.constraint_string;
+    }
+  }
+
+  return constraint_solver;
+}
+
+absl::StatusOr<ConstraintSolver> ConstraintSolver::Create(
+    const ActionInfo& action) {
+  ConstraintSolver constraint_solver = ConstraintSolver();
+  constraint_solver.action_info_ = action;
+
+  // Initialize symbolic variables for action parameters.
+  for (const auto& [param_name, param_info] : action.params_by_name) {
+    ASSIGN_OR_RETURN(int bitwidth, ast::TypeBitwidthOrStatus(param_info.type));
+    if (bitwidth <= 0) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "expected a param type with bitwidth > 0, but got: "
+             << param_info.name << " with type "
+             << param_info.type.ShortDebugString();
+    }
+    // Action parameters are just bitvectors.
+    z3::expr param_expr =
+        constraint_solver.solver_->ctx().bv_const(param_name.c_str(), bitwidth);
+    constraint_solver.environment_.symbolic_parameter_by_name.insert(
+        {param_name, param_expr});
+  }
+
+  if (action.constraint.has_value()) {
+    ASSIGN_OR_RETURN(bool modeled_constraint_added,
+                     constraint_solver.AddConstraintInternal(
+                         *action.constraint, action.constraint_source));
+    if (!modeled_constraint_added) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "ActionInfo provided an unsatisfiable constraint. "
+                "ConstraintSolver must contain a satisfiable constraint at all "
+                "times so creation failed.\n Unsatisfiable Constraint: "
+             << action.constraint_source.constraint_string;
     }
   }
 
@@ -971,6 +1056,21 @@ absl::StatusOr<z3::expr> TranslateBySymbolicEnvironment(
     z3::expr_vector from(expr.ctx());
     z3::expr_vector to(expr.ctx());
     from.push_back(src_attribute.value);
+    to.push_back(translated_dst_value);
+    expr = expr.substitute(from, to);
+  }
+
+  // Substitute parameter names.
+  for (const auto& [param_name, dst_param] :
+       dst_env.symbolic_parameter_by_name) {
+    auto src_it = src_env.symbolic_parameter_by_name.find(param_name);
+    if (src_it == src_env.symbolic_parameter_by_name.end()) continue;
+    const z3::expr& src_param = src_it->second;
+    z3::expr translated_dst_value = z3::to_expr(
+        expr.ctx(), Z3_translate(dst_param.ctx(), dst_param, expr.ctx()));
+    z3::expr_vector from(expr.ctx());
+    z3::expr_vector to(expr.ctx());
+    from.push_back(src_param);
     to.push_back(translated_dst_value);
     expr = expr.substitute(from, to);
   }

--- a/p4_constraints/backend/symbolic_interpreter.h
+++ b/p4_constraints/backend/symbolic_interpreter.h
@@ -88,13 +88,14 @@ struct SymbolicEnvironment {
   absl::flat_hash_map<std::string, SymbolicKey> symbolic_key_by_name;
   absl::flat_hash_map<std::string, SymbolicAttribute>
       symbolic_attribute_by_name;
+  absl::flat_hash_map<std::string, z3::expr> symbolic_parameter_by_name;
 };
 
 // -- Main Class ---------------------------------------------------------------
 
-// A solver for constraints on a table.
-// NOTE: Encodes a single table entry for the table given to the constructor. A
-// single instantiation can not be used to encode multiple entries.
+// A solver for constraints on a table or action.
+// NOTE: Encodes a single table entry or action at a time. A single
+// instantiation can not be used to encode multiple entries or actions.
 class ConstraintSolver {
  public:
   // Constructs a ConstraintSolver representing an entry for `table` that
@@ -106,22 +107,21 @@ class ConstraintSolver {
       std::function<absl::StatusOr<bool>(absl::string_view key_name)>
           skip_key_named = [](absl::string_view key_name) { return false; });
 
-  // Returns true and adds constraint to the solver. If `constraint` would make
-  // the current ConstraintSolver unable to generate an entry, returns false and
-  // does not change the state of the ConstraintSolver. If `constraint` is
-  // malformed returns error and `constraint_source` is used for debugging info.
-  absl::StatusOr<bool> AddConstraint(const ast::Expression& constraint,
-                                     const ConstraintSource& constraint_source);
-  // Similar to overload above except that both the AST expression and its
-  // source are derived from `constraint`. Additionally returns an error if a
-  // valid AST cannot be produced from `constraint`.
-  absl::StatusOr<bool> AddConstraint(absl::string_view constraint);
+  // Constructs a ConstraintSolver representing action parameter values for
+  // `action` that respects its P4-Constraints.
+  static absl::StatusOr<ConstraintSolver> Create(const ActionInfo& action);
 
-  // Returns the entry encoded by the object.
-  // NOTE: The entry will NOT contain an action and is thus not a valid
-  // P4Runtime entry without modification.
-  // TODO(b/242201770): Extract actions once action constraints are supported.
-  absl::StatusOr<p4::v1::TableEntry> ConcretizeEntry();
+  // Returns true and adds a table constraint to the solver. If `constraint` is
+  // malformed or would make the current ConstraintSolver unable to generate
+  // an entry, returns false/error and does not change the state of the solver.
+  // Additionally returns an error if a valid AST cannot be produced.
+  absl::StatusOr<bool> AddTableConstraint(absl::string_view constraint);
+
+  // Returns the entry encoded by the object (keys and priority only).
+  absl::StatusOr<p4::v1::TableEntry> ConcretizeEntryKey();
+
+  // Returns the action encoded by the object.
+  absl::StatusOr<p4::v1::Action> ConcretizeAction();
 
   // Adds the ConstraintSolver's constraints to the target solver.
   // Renames variables according to the passed SymbolicEnvironment as needed.
@@ -133,15 +133,20 @@ class ConstraintSolver {
       : context_(std::make_unique<z3::context>()),
         solver_(std::make_unique<z3::solver>(*context_)) {}
 
+  absl::StatusOr<bool> AddConstraintInternal(
+      const ast::Expression& constraint,
+      const ConstraintSource& constraint_source);
+
   // Z3 context and solver. 'solver' requires a reference to `context` for
   // construction so it is privately stored to avoid dangling reference.
   std::unique_ptr<z3::context> context_;
   std::unique_ptr<z3::solver> solver_;
 
-  // TableInfo of table that is being constrained.
-  TableInfo table_info_;
+  std::optional<TableInfo> table_info_;
+  std::optional<ActionInfo> action_info_;
 
-  // Symbolic environment for storing information on symbolic keys.
+  // Symbolic environment for storing information on symbolic keys, params, and
+  // attributes.
   SymbolicEnvironment environment_;
 
   // Function to determine whether a key should be ignored while creating

--- a/p4_constraints/backend/symbolic_interpreter_test.cc
+++ b/p4_constraints/backend/symbolic_interpreter_test.cc
@@ -607,7 +607,7 @@ TEST(CreateConstraintSolver, WorksWithoutConstraints) {
   EXPECT_OK(ConstraintSolver::Create(table_info));
 }
 
-TEST(CreateConstraintSolverAddConstraint, WorksWithoutPriority) {
+TEST(CreateConstraintSolverAddTableConstraint, WorksWithoutPriority) {
   TableInfo table_info = GetTableInfoWithConstraint("true");
 
   // Remove the ternaries and optionals, so that no priority is required.
@@ -645,7 +645,7 @@ TEST_P(ConstraintTest, CreateConstraintSolverAndConcretizeEntry) {
                        ConstraintSolver::Create(table_info));
 
   ASSERT_OK_AND_ASSIGN(p4::v1::TableEntry concretized_entry,
-                       constraint_solver.ConcretizeEntry());
+                       constraint_solver.ConcretizeEntryKey());
 
   // The empty string signifies that the entry doesn't violate the constraint.
   ConstraintInfo context{
@@ -807,7 +807,7 @@ TEST_P(FullySpecifiedConstraintTest,
       }));
 
   ASSERT_OK_AND_ASSIGN(p4::v1::TableEntry concretized_entry,
-                       constraint_solver.ConcretizeEntry());
+                       constraint_solver.ConcretizeEntryKey());
 
   EXPECT_THAT(concretized_entry,
               EqualsProto(GetParam().expected_concretized_entry));
@@ -999,32 +999,144 @@ INSTANTIATE_TEST_SUITE_P(
       return SnakeCaseToCamelCase(info.param.test_name);
     });
 
-TEST(AddConstraint, NonBooleanConstraintGivesInvalidArgument) {
+ActionInfo GetActionInfoWithConstraint(absl::string_view constraint_string) {
+  const Type kBit32 = ParseProtoOrDie<Type>("fixed_unsigned { bitwidth: 32 }");
+  const Type kBit16 = ParseProtoOrDie<Type>("fixed_unsigned { bitwidth: 16 }");
+  const std::string kActionName = "action";
+
+  ConstraintSource source{
+      .constraint_string = std::string(constraint_string),
+      .constraint_location = ast::SourceLocation(),
+  };
+  source.constraint_location.set_action_name(kActionName);
+
+  ActionInfo action_info{
+      .id = 1,
+      .name = kActionName,
+      .constraint_source = std::move(source),
+      .params_by_id =
+          {
+              {1, {1, "param32", kBit32}},
+              {2, {2, "param16", kBit16}},
+          },
+      .params_by_name =
+          {
+              {"param32", {1, "param32", kBit32}},
+              {"param16", {2, "param16", kBit16}},
+          },
+  };
+
+  auto constraint = ParseConstraint(ConstraintKind::kActionConstraint,
+                                    action_info.constraint_source);
+  CHECK_OK(constraint);
+  CHECK_OK(InferAndCheckTypes(&(*constraint), action_info));
+  action_info.constraint = *constraint;
+
+  return action_info;
+}
+
+struct FullySpecifiedActionConstraintTestCase {
+  std::string test_name;
+  std::string constraint_string;
+  p4::v1::Action expected_action;
+};
+
+using FullySpecifiedActionConstraintTest =
+    testing::TestWithParam<FullySpecifiedActionConstraintTestCase>;
+
+TEST_P(FullySpecifiedActionConstraintTest,
+       CreateConstraintSolverAndConcretizeActionGivesExactAction) {
+  ActionInfo action_info =
+      GetActionInfoWithConstraint(GetParam().constraint_string);
+
+  TableInfo dummy_table_info{
+      .id = 1,
+      .name = "dummy_table",
+  };
+
+  ConstraintInfo context{
+      .action_info_by_id = {{
+          action_info.id,
+          action_info,
+      }},
+      .table_info_by_id = {{
+          dummy_table_info.id,
+          dummy_table_info,
+      }},
+  };
+
+  p4::v1::TableEntry dummy_entry;
+  dummy_entry.set_table_id(dummy_table_info.id);
+  *dummy_entry.mutable_action()->mutable_action() = GetParam().expected_action;
+
+  ASSERT_THAT(ReasonEntryViolatesConstraint(dummy_entry, context),
+              IsOkAndHolds(""))
+      << "\nFor action:\n"
+      << GetParam().expected_action.DebugString()
+      << "\nConstraint string: " << GetParam().constraint_string
+      << "\nConstraint: " << action_info.constraint->DebugString();
+
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver constraint_solver,
+                       ConstraintSolver::Create(action_info));
+
+  ASSERT_OK_AND_ASSIGN(p4::v1::Action concretized_action,
+                       constraint_solver.ConcretizeAction());
+
+  EXPECT_THAT(concretized_action, EqualsProto(GetParam().expected_action));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CheckExactActionOutput, FullySpecifiedActionConstraintTest,
+    testing::ValuesIn(std::vector<FullySpecifiedActionConstraintTestCase>{
+        {
+            .test_name = "only_equals",
+            .constraint_string = "param32 == 42; param16 == 5;",
+            .expected_action = ParseProtoOrDie<p4::v1::Action>(R"pb(
+              action_id: 1
+              params { param_id: 2 value: "\005" }
+              params { param_id: 1 value: "*" }
+            )pb"),
+        },
+        {
+            .test_name = "inequalities_and_bounds",
+            .constraint_string = "param32 > 41; param32 < 43; param16 == 5;",
+            .expected_action = ParseProtoOrDie<p4::v1::Action>(R"pb(
+              action_id: 1
+              params { param_id: 2 value: "\005" }
+              params { param_id: 1 value: "*" }
+            )pb"),
+        },
+    }),
+    [](const testing::TestParamInfo<FullySpecifiedActionConstraintTestCase>&
+           info) { return SnakeCaseToCamelCase(info.param.test_name); });
+
+TEST(AddTableConstraint, NonBooleanConstraintGivesInvalidArgument) {
   ASSERT_OK_AND_ASSIGN(
       ConstraintSolver constraint_solver,
       ConstraintSolver::Create(GetTableInfoWithConstraint("true")));
 
-  EXPECT_THAT(constraint_solver.AddConstraint("42"),
+  EXPECT_THAT(constraint_solver.AddTableConstraint("42"),
               StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
-TEST(AddConstraint, UnknownVariableGivesInvalidArgument) {
+TEST(AddTableConstraint, UnknownVariableGivesInvalidArgument) {
   ASSERT_OK_AND_ASSIGN(
       ConstraintSolver constraint_solver,
       ConstraintSolver::Create(GetTableInfoWithConstraint("true")));
 
-  EXPECT_THAT(constraint_solver.AddConstraint("dragon == 42"),
+  EXPECT_THAT(constraint_solver.AddTableConstraint("dragon == 42"),
               StatusIs(absl::StatusCode::kInvalidArgument));
 }
 
-TEST(AddConstraint, OnlySatisfiableConstraintCanBeAdded) {
+TEST(AddTableConstraint, OnlySatisfiableConstraintCanBeAdded) {
   ASSERT_OK_AND_ASSIGN(
       ConstraintSolver constraint_solver,
       ConstraintSolver::Create(GetTableInfoWithConstraint("true")));
 
-  EXPECT_THAT(constraint_solver.AddConstraint("false"), IsOkAndHolds(false));
+  EXPECT_THAT(constraint_solver.AddTableConstraint("false"),
+              IsOkAndHolds(false));
 
-  EXPECT_THAT(constraint_solver.AddConstraint("true"), IsOkAndHolds(true));
+  EXPECT_THAT(constraint_solver.AddTableConstraint("true"), IsOkAndHolds(true));
 }
 
 struct AdditionalConstraintTestCase {
@@ -1040,7 +1152,7 @@ using AdditionalConstraintTest =
     testing::TestWithParam<AdditionalConstraintTestCase>;
 
 TEST_P(AdditionalConstraintTest,
-       AddConstraintOnlyAddsSatisfiableConstraintsToSolver) {
+       AddTableConstraintOnlyAddsSatisfiableConstraintsToSolver) {
   TableInfo table_info =
       GetTableInfoWithConstraint(GetParam().p4_program_constraint_string);
 
@@ -1048,11 +1160,11 @@ TEST_P(AdditionalConstraintTest,
                        ConstraintSolver::Create(table_info));
 
   EXPECT_THAT(
-      constraint_solver.AddConstraint(GetParam().custom_constraint_string),
+      constraint_solver.AddTableConstraint(GetParam().custom_constraint_string),
       IsOkAndHolds(GetParam().is_sat));
 }
 
-TEST_P(AdditionalConstraintTest, AddConstraintAndConcretizeEntry) {
+TEST_P(AdditionalConstraintTest, AddTableConstraintAndConcretizeEntry) {
   if (!GetParam().is_sat) {
     GTEST_SKIP() << "Test only sensible for satisfiable constraints";
   }
@@ -1064,11 +1176,11 @@ TEST_P(AdditionalConstraintTest, AddConstraintAndConcretizeEntry) {
                        ConstraintSolver::Create(table_info));
 
   ASSERT_THAT(
-      constraint_solver.AddConstraint(GetParam().custom_constraint_string),
+      constraint_solver.AddTableConstraint(GetParam().custom_constraint_string),
       IsOkAndHolds(true));
 
   ASSERT_OK_AND_ASSIGN(p4::v1::TableEntry concretized_entry,
-                       constraint_solver.ConcretizeEntry());
+                       constraint_solver.ConcretizeEntryKey());
 
   // The empty string signifies that the entry doesn't violate the
   ConstraintInfo context{
@@ -1170,11 +1282,11 @@ TEST_P(FullySpecifiedAdditionalConstraintTest,
                        ConstraintSolver::Create(table_info));
 
   ASSERT_THAT(
-      constraint_solver.AddConstraint(GetParam().custom_constraint_string),
+      constraint_solver.AddTableConstraint(GetParam().custom_constraint_string),
       IsOkAndHolds(true));
 
   ASSERT_OK_AND_ASSIGN(p4::v1::TableEntry concretized_entry,
-                       constraint_solver.ConcretizeEntry());
+                       constraint_solver.ConcretizeEntryKey());
 
   EXPECT_THAT(concretized_entry,
               EqualsProto(GetParam().expected_concretized_entry));
@@ -1445,6 +1557,80 @@ TEST(ExportConstraintsToTargetSolverTest,
               StatusIs(absl::StatusCode::kInternal,
                        testing::HasSubstr(
                            "Mismatched Z3 sorts during symbolic translation")));
+}
+
+TEST(ExportConstraintsToTargetSolverTest,
+     ExportConstraintsCorrectlyRenamesActionParameters) {
+  ActionInfo action_info =
+      GetActionInfoWithConstraint("param32 == 42 && param16 == 12");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver source_solver,
+                       ConstraintSolver::Create(action_info));
+
+  z3::context dest_context;
+  z3::solver dest_solver(dest_context);
+
+  // Change one parameter name to make sure the renaming works.
+  z3::expr renamed_param32 = dest_context.bv_const("param32_renamed", 32);
+  SymbolicEnvironment dest_environment;
+  dest_environment.symbolic_parameter_by_name.insert(
+      {"param32", renamed_param32});
+
+  ASSERT_OK(source_solver.ExportConstraintsToTargetSolver(dest_solver,
+                                                          dest_environment));
+
+  // Check that the constraint "param32_renamed == 42" has been added
+  // correctly.
+  EXPECT_EQ(dest_solver.check(), z3::sat);
+  dest_solver.push();
+  dest_solver.add(renamed_param32 != 42);
+  EXPECT_EQ(dest_solver.check(), z3::unsat);
+  dest_solver.pop();
+
+  // Check that other constraints have been added correctly.
+  // The constraint "param16 == 12" should have been added to dest_solver.
+  dest_solver.push();
+  z3::expr param16_in_dest = dest_context.bv_const("param16", 16);
+  dest_solver.add(param16_in_dest == 12);
+  EXPECT_EQ(dest_solver.check(), z3::sat);
+  dest_solver.add(param16_in_dest != 12);
+  EXPECT_EQ(dest_solver.check(), z3::unsat);
+  dest_solver.pop();
+}
+
+TEST(ActionConstraintSolverTest, WorksWithoutConstraints) {
+  ActionInfo action_info = GetActionInfoWithConstraint("true");
+  action_info.constraint = std::nullopt;
+
+  EXPECT_OK(ConstraintSolver::Create(action_info));
+}
+
+TEST(ActionConstraintSolverTest, OnlyWorksWithSatisfiableConstraints) {
+  ActionInfo sat_action_info = GetActionInfoWithConstraint("param32 == 42");
+  EXPECT_OK(ConstraintSolver::Create(sat_action_info));
+
+  ActionInfo unsat_action_info =
+      GetActionInfoWithConstraint("param32 == 42 && param32 == 43");
+  EXPECT_THAT(ConstraintSolver::Create(unsat_action_info),
+              StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(ConstraintSolverPreconditionTest, ConcretizeActionFailsWithoutActionInfo) {
+  TableInfo table_info = GetTableInfoWithConstraint("true");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver constraint_solver,
+                       ConstraintSolver::Create(table_info));
+
+  EXPECT_THAT(constraint_solver.ConcretizeAction(),
+              StatusIs(absl::StatusCode::kFailedPrecondition));
+}
+
+TEST(ConstraintSolverPreconditionTest,
+     ConcretizeEntryKeyFailsWithoutTableInfo) {
+  ActionInfo action_info = GetActionInfoWithConstraint("true");
+  ASSERT_OK_AND_ASSIGN(ConstraintSolver constraint_solver,
+                       ConstraintSolver::Create(action_info));
+
+  EXPECT_THAT(constraint_solver.ConcretizeEntryKey(),
+              StatusIs(absl::StatusCode::kFailedPrecondition));
 }
 
 }  // namespace

--- a/p4_constraints/backend/type_checker.cc
+++ b/p4_constraints/backend/type_checker.cc
@@ -111,7 +111,7 @@ bool StrictlyAboveInCastabilityOrder(const Type& left, const Type& right) {
 // two types in the castability diagram above, where an ancestor is a type
 // reachable via am upward path. Note that such a supremum (common ancestor)
 // does not exist for all pairs of types.
-absl::optional<Type> LeastUpperBound(const Type& left, const Type& right) {
+std::optional<Type> LeastUpperBound(const Type& left, const Type& right) {
   if (left == right) return left;
   if (StrictlyAboveInCastabilityOrder(left, right)) return left;
   if (StrictlyAboveInCastabilityOrder(right, left)) return right;
@@ -169,7 +169,7 @@ absl::Status CastTransitivelyTo(Expression* expr, Type target_type) {
 // upper bound. Otherwise, Unify returns an InvalidArgument Status.
 absl::StatusOr<Type> Unify(Expression* left, Expression* right,
                            const ConstraintSource& constraint_source) {
-  const absl::optional<Type> least_upper_bound =
+  const std::optional<Type> least_upper_bound =
       LeastUpperBound(left->type(), right->type());
   if (!least_upper_bound.has_value()) {
     return StaticTypeError(constraint_source, left->start_location(),
@@ -199,13 +199,13 @@ const auto* const kFieldTypes =
         {std::make_tuple(Type::kOptionalMatch, "mask"), Type::kFixedUnsigned},
     };
 
-absl::optional<Type> FieldTypeOfCompositeType(const Type& composite_type,
-                                              const std::string& field) {
+std::optional<Type> FieldTypeOfCompositeType(const Type& composite_type,
+                                             const std::string& field) {
   auto it =
       kFieldTypes->find(std::make_tuple(composite_type.type_case(), field));
   if (it == kFieldTypes->end()) return {};
   Type field_type = TypeCaseToType(it->second);
-  absl::optional<int> bitwidth = TypeBitwidth(composite_type);
+  std::optional<int> bitwidth = TypeBitwidth(composite_type);
   if (!bitwidth.has_value()) {
     LOG(ERROR) << "expected composite type " << composite_type
                << " to have bitwidth";

--- a/p4_constraints/cli/BUILD.bazel
+++ b/p4_constraints/cli/BUILD.bazel
@@ -1,9 +1,8 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 
-package(
-    default_visibility = ["//visibility:public"],
-    licenses = ["notice"],  # Apache 2.0
-)
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 cc_binary(
     name = "p4check",

--- a/p4_constraints/frontend/BUILD.bazel
+++ b/p4_constraints/frontend/BUILD.bazel
@@ -1,9 +1,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-package(
-    licenses = ["notice"],  # Apache 2.0
-)
+licenses(["notice"])
 
 cc_library(
     name = "parser",


### PR DESCRIPTION
PUBLIC: Implement support for action constraints in ConstraintSolver.

This change introduces the ability to create a ConstraintSolver for an ActionInfo, allowing the symbolic interpretation of action constraints and the concretization of action parameters. The existing methods for table constraints have been renamed to be more specific.

Signed-off-by: verios-google <verios@google.com>
