### PR TITLE
PUBLIC: Support named types in P4 constraints action parameters.

### DIFF
--- a/docs/language-specification.md
+++ b/docs/language-specification.md
@@ -96,6 +96,12 @@ When `k` is of type `bool`, everything behaves precisely as if `k` was of type
 `bit<1>`, with the boolean constant `true` and `false` being mapped to `1` and
 `0`, respectively.
 
+*Note on Action Parameters:* Currently, `bool` action parameters are not
+supported in action constraints. Action parameters must be representable as
+bitstrings with a positive bitwidth (i.e. `bit<W>`). If a `bool` action
+parameter is not mapped to a positive `bitwidth` in the P4Info, it will be
+treated as unsupported.
+
 
 ### Assumed P4runtime Well-Formedness Constraints
 

--- a/p4_constraints/backend/constraint_info.cc
+++ b/p4_constraints/backend/constraint_info.cc
@@ -216,14 +216,22 @@ absl::StatusOr<ast::Type> ParseKeyType(const MatchField& key) {
 
 absl::StatusOr<ast::Type> ParseParamType(const Action_Param& param) {
   ast::Type type;
+  // If the parameter has a bitwidth, we can treat it as fixed_unsigned,
+  // even if it has a user-defined type name (e.g., typedef bit<W>).
+  if (param.bitwidth() > 0) {
+    type.mutable_fixed_unsigned()->set_bitwidth(param.bitwidth());
+    return type;
+  }
+
   // P4NamedType is unset if the param does not use a user-defined type.
-  // Currently we do not support user-defined types.
+  // Types without a positive bitwidth (e.g., bool, string) are currently
+  // unsupported as action parameters in constraints.
   if (!param.type_name().name().empty()) {
     type.mutable_unsupported()->set_name(param.type_name().name());
     return type;
   }
 
-  type.mutable_fixed_unsigned()->set_bitwidth(param.bitwidth());
+  type.mutable_unsupported()->set_name("unknown");
   return type;
 }
 

--- a/p4_constraints/backend/constraint_info_test.cc
+++ b/p4_constraints/backend/constraint_info_test.cc
@@ -69,7 +69,8 @@ TEST(P4ToConstraintInfoTest, ValidActionRestrictionSucceeds) {
             "multicast_group_id != 0");
 }
 
-TEST(P4ToConstraintInfoTest, ActionWithP4NamedTypeConstraintFails) {
+TEST(P4ToConstraintInfoTest,
+     ActionWithP4NamedTypeAndBitwidthConstraintSucceeds) {
   P4Info p4_info;
 
   std::string_view proto_string =
@@ -79,23 +80,52 @@ TEST(P4ToConstraintInfoTest, ActionWithP4NamedTypeConstraintFails) {
         id: 123
         name: "MyIngress.act_2"
         alias: "act_2"
-        annotations: "@action_restriction(\"custom_type_param != 0\")"
+        annotations: "@action_restriction(\"custom_type_with_bitwidth_param != 0\")"
       }
       params {
         id: 1
-        name: "custom_type_param"
+        name: "custom_type_with_bitwidth_param"
         bitwidth: 16
-        type_name { name: "custom_type_t" }
+        type_name { name: "custom_type_with_bitwidth_t" }
       }
     }
       )pb";
 
   ASSERT_OK(gutil::ReadProtoFromString(proto_string, &p4_info));
 
-  absl::StatusOr<ConstraintInfo> constraints =
-      p4_constraints::P4ToConstraintInfo(p4_info);
+  ASSERT_OK_AND_ASSIGN(const ConstraintInfo constraints,
+                       p4_constraints::P4ToConstraintInfo(p4_info));
 
-  EXPECT_TRUE(!constraints.ok());
+  EXPECT_EQ(
+      constraints.action_info_by_id.at(123).constraint_source.constraint_string,
+      "custom_type_with_bitwidth_param != 0");
+}
+
+TEST(P4ToConstraintInfoTest,
+     ActionWithP4NamedTypeAndNoBitwidthConstraintFails) {
+  P4Info p4_info;
+
+  std::string_view proto_string =
+      R"pb(
+    actions {
+      preamble {
+        id: 123
+        name: "MyIngress.act_2"
+        alias: "act_2"
+        annotations: "@action_restriction(\"custom_type_without_bitwidth_param != 0\")"
+      }
+      params {
+        id: 1
+        name: "custom_type_without_bitwidth_param"
+        bitwidth: 0
+        type_name { name: "custom_type_without_bitwidth_t" }
+      }
+    }
+      )pb";
+
+  ASSERT_OK(gutil::ReadProtoFromString(proto_string, &p4_info));
+
+  EXPECT_FALSE(p4_constraints::P4ToConstraintInfo(p4_info).ok());
 }
 
 TEST(P4ToConstraintInfoTest, ConstraintAnnotationsMustBeEnclosedInParen) {


### PR DESCRIPTION
PUBLIC: Support named types in P4 constraints action parameters.

Previously, parameters with user-defined/named type names were treated as unsupported in `p4_constraints/backend/constraint_info.cc`. This caused type-checking to fail for constraints referencing these parameters.

To work around this, `p4_fuzzer/constraints.cc` marked all actions with named type parameters as unsupported, disabling constraint solving for them and leading to random value generation that could fail runtime checks.

This CL fixes the issue by:
1. Modifying `ParseParamType` in `constraint_info.cc` to support named types as long as they have a bitwidth > 0 (treating them as `fixed_unsigned`).
2. Modifying `ActionHasUnsupportedParamTypes` in `p4_fuzzer/constraints.cc` to check if the parameter has a valid bitwidth instead of checking if it has a named type.
3. Updating tests in both packages to verify the new behavior.
4. Documenting the limitation regarding `bool` action parameters in `language-specification.md` and adding a comment in `constraint_info.cc` referencing the feature request bug (b/524731234) using copybara strip.
5. Adding a test case in `constraint_info_test.cc` to verify that named types without bitwidth still fail validation.

Signed-off-by: verios-google <verios@google.com>
